### PR TITLE
Add timeout for sending new power states

### DIFF
--- a/index.js
+++ b/index.js
@@ -593,11 +593,13 @@ eWeLink.prototype.setPowerState = function(accessory, isOn, callback) {
 
     if (platform.isSocketOpen) {
 
-        platform.wsc.send(string);
+        setTimeout(function() {
+            platform.wsc.send(string);
 
-        // TODO Here we need to wait for the response to the socket
+            // TODO Here we need to wait for the response to the socket
 
-        callback();
+            callback();
+        }, 1);
 
     } else {
         callback('Socket was closed. It will reconnect automatically; please retry your command');


### PR DESCRIPTION
Hey,

I've encountered an issue when grouping sockets (S26) or using automations on multiple sockets. It seems that only one socket gets toggled while all others stay at their state. Therefore I've added a small delay for sending the web socket messages to prevent any issues with multiple simultaneous requests.