### PR TITLE
Re-add the missing Fan Device Type Channels

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,19 @@ function eWeLink(log, config, api) {
                             accessory.getService(Service.AccessoryInformation).setCharacteristic(Characteristic.Model, deviceInformationFromWebApi.extra.extra.model + ' (' + deviceInformationFromWebApi.uiid + ')');
                             accessory.getService(Service.AccessoryInformation).setCharacteristic(Characteristic.FirmwareRevision, deviceInformationFromWebApi.params.fwVersion);
 
+                            
+                            switch(deviceInformationFromWebApi.extra.extra.model) {
+                                case 'PSF-B04-GL' :
+                                    switchesAmount = 3;
+                                    break;
+                                case 'PSB-B04-GL' :
+                                    switchesAmount = 2;
+                                    break;
+                                case 'PSF-A04-GL' :
+                                    switchesAmount = 4;
+                                    break;
+                            }
+                            
                             if(switchesAmount > 1) {
                                 platform.log(switchesAmount + " channels device has been set: " + deviceInformationFromWebApi.extra.extra.model + ' uiid: ' + deviceInformationFromWebApi.uiid);
                                 for(let i=0; i!==switchesAmount; i++) {
@@ -182,6 +195,18 @@ function eWeLink(log, config, api) {
                             let deviceToAdd = platform.devicesFromApi.get(deviceId);
                             let switchesAmount = platform.getDeviceChannelCount(deviceToAdd);
 
+                            switch(deviceToAdd.extra.extra.model) {
+                                case 'PSF-B04-GL' :
+                                    switchesAmount = 3;
+                                    break;
+                                case 'PSB-B04-GL' :
+                                    switchesAmount = 2;
+                                    break;
+                                case 'PSF-A04-GL' :
+                                    switchesAmount = 4;
+                                    break;
+                            }
+                            
                             let services = {};
                             services.switch = true;
 
@@ -202,6 +227,8 @@ function eWeLink(log, config, api) {
                                 platform.addAccessory(deviceToAdd, null, services);
                             }
                         }
+                        
+                        
                     }
 
                     // Go through the web response to make sure that all the devices that are in the response do exist in the accessories map
@@ -487,6 +514,18 @@ eWeLink.prototype.addAccessory = function(device, deviceId = null, services = { 
         accessory.context.switches = switchesAmount;
     }
 
+    switch(device.extra.extra.model) {
+        case 'PSF-B04-GL' :
+             accessory.context.switches = 3;
+            break;
+        case 'PSB-B04-GL' :
+            accessory.context.switches = 2;
+            break;
+        case 'PSF-A04-GL' :
+            accessory.context.switches = 4;
+            break;
+    }
+    
     this.accessories.set(device.deviceid, accessory);
 
     this.api.registerPlatformAccessories("homebridge-eWeLink",

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function eWeLink(log, config, api) {
                             
                             switch(deviceInformationFromWebApi.extra.extra.model) {
                                 case 'PSF-B04-GL' :
-                                    switchesAmount = 3;
+                                    switchesAmount = 4;
                                     break;
                                 case 'PSB-B04-GL' :
                                     switchesAmount = 2;
@@ -197,7 +197,7 @@ function eWeLink(log, config, api) {
 
                             switch(deviceToAdd.extra.extra.model) {
                                 case 'PSF-B04-GL' :
-                                    switchesAmount = 3;
+                                    switchesAmount = 4;
                                     break;
                                 case 'PSB-B04-GL' :
                                     switchesAmount = 2;
@@ -516,7 +516,7 @@ eWeLink.prototype.addAccessory = function(device, deviceId = null, services = { 
 
     switch(device.extra.extra.model) {
         case 'PSF-B04-GL' :
-             accessory.context.switches = 3;
+             accessory.context.switches = 4;
             break;
         case 'PSB-B04-GL' :
             accessory.context.switches = 2;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/howanghk/homebridge-ewelink"
+    "url": "https://github.com/JangoBritt/homebridge-ewelink"
   },
   "dependencies": {
     "nonce": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/JangoBritt/homebridge-ewelink"
+    "url": "https://github.com/howanghk/homebridge-ewelink"
   },
   "dependencies": {
     "nonce": "^1.0.4",


### PR DESCRIPTION
There was a disparity between the howanghk master branch, and the MrTomAsh master branch that was missing the Device Type Channels for devices including the iFan02.

I've re-merged them, and tested. This displays as 4 channels in HomeKit, CH1 for light, and CH2-4 for the three speed settings of the fan.

Obviously this is quick and dirty implementation, and I'd prefer to present a proper Fan device type made up of the three channels (OFF/33%/66%/100%). As it is, it appears as extra device tiles.

This at least resolved the problems of the device appearing offline