### PR TITLE
Bug fixed when using multi channels devices and another minor issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -753,7 +753,9 @@ eWeLink.prototype.addAccessory = function (device, deviceId = null, services = {
 
     accessory.on('identify', function (paired, callback) {
         platform.log(accessory.displayName, "Identify not supported");
-        callback();
+	try {
+            callback();
+	} catch (e) { }
     });
 
     accessory.getService(Service.AccessoryInformation).setCharacteristic(Characteristic.SerialNumber, device.extra.extra.mac);

--- a/index.js
+++ b/index.js
@@ -773,7 +773,7 @@ eWeLink.prototype.addAccessory = function (device, deviceId = null, services = {
         accessory.context.switches = switchesAmount;
     }
 
-    this.accessories.set(device.deviceid, accessory);
+    this.accessories.set(deviceId ? deviceId : device.deviceid, accessory);
 
     this.api.registerPlatformAccessories("homebridge-eWeLink",
         "eWeLink", [accessory]);


### PR DESCRIPTION
Resolved a problem that occurred when using devices with multiple channels, like the Sonoff 4CH or the 2CH. There was an error saving the correct device id as key for the local cache. The result was that plugin try to create a new accessories with the classic error "Cannot add a bridged Accessory with the same UUID as another bridged Accessory".

Resolved an error that may occur while adding a new Homebridge (so multiple accessories at the same time) in the iPhone Home app.