### PR TITLE
Initial Lan Mode Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+node_modules

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -1,0 +1,246 @@
+let request = require('request-json');
+let crypto = require('crypto');
+
+const mdns = require('multicast-dns')()
+
+
+module.exports = class LanClient {
+
+
+
+    /**
+     * 
+     * @param {*} device 
+     * @param {*} log the logger instance to use for log messages
+     */
+    constructor(device, log) {
+
+        this.device = device;
+        this.log = log;
+
+        this.deviceName = 'eWeLink_' + device.deviceid + '._ewelink._tcp.local';
+
+    }
+
+    start() {
+        mdns.on('response', response => this.processDnsResponse(response));
+
+        /* Send the initial query */
+        mdns.query({
+            questions: [
+                {
+                    name: '_ewelink._tcp.local',
+                    // type: 'PTR'
+                    // name: 'MacBook.local',
+                    type: 'TXT'
+                }
+            ]
+        });
+    }
+
+
+    processDnsResponse(response) {
+
+        /* find the item for the device */
+        if (response.answers) {
+            response.answers
+                .filter(value => value.name === this.deviceName && value.type === 'TXT')
+                .forEach(value => {
+                    this.log.debug('got a matching response for device %s: %o',
+                        this.device.deviceid, value)
+
+                    let dataObject = {};
+
+                    value.data.forEach(dataValue => {
+                        this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
+
+                        let bufferString = dataValue.toString('utf-8');
+                        let key = bufferString.substr(0, bufferString.indexOf('='));
+
+                        dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
+                    });
+
+                    this.log.debug('DNS txt record for device %s is: %o',
+                        this.device.deviceid, dataObject);
+
+                    
+                    /* Turn this TXT record into something usable for the state */
+                    const stateData = this.extractDataFromDnsService(dataObject, this.device.devicekey);
+                    this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
+                });
+
+        }
+    }
+
+
+    /**
+     * Decrypt the supplied data. 
+     * @param encryptedData the data to decrypt
+     * @param apiKey the API key for the device the encrypted data is for
+     * @param iv the initialisation vector associated with the encrypted message. 
+     * @returns string containing the decrypted data
+     */
+    decrypt(encryptedData, apiKey, iv) {
+        const cryptkey = crypto.createHash('md5')
+            .update(Buffer.from(apiKey, 'utf8'))
+            .digest();
+
+        const ivBuffer = Buffer.from(iv, 'base64');
+
+        const cipherText = Buffer.from(encryptedData, 'base64');
+
+
+        const decipher = crypto.createDecipheriv('aes-128-cbc', cryptkey, ivBuffer);
+
+        const plainText = Buffer.concat([
+            decipher.update(cipherText),
+            decipher.final(),
+        ]);
+
+        return plainText.toString('utf8');
+    }
+
+    /**
+    * Encrypt the supplied data. 
+    * @param plainText the data to encrypt
+    * @param apiKey the API key for the device the encrypted data is for
+    * @returns object containing the encrypted "data" and "iv" used for the encryption
+    */
+    encrypt(plainText, apiKey) {
+
+        const cryptkey = crypto.createHash('md5')
+            .update(Buffer.from(apiKey, 'utf8'))
+            .digest();
+
+        const iv = crypto.randomBytes(16);
+
+        const encipher = crypto.createCipheriv('aes-128-cbc', cryptkey, iv);
+
+        const cipherText = Buffer.concat([
+            encipher.update(plainText),
+            encipher.final(),
+        ]);
+
+        return {
+            data: cipherText,
+            iv: iv,
+        };
+
+    };
+
+    /**
+     * Extract the state data object from the MDNS service.
+     *
+     * @param service the service TXT record data from the mdns query
+     * @param deviceKey optional parameter. If this service is marked as encrypted then this 
+     *                  is required for part of the decryption, this is the decryption key.
+     * @returns object containing the data
+     */
+    extractDataFromDnsService(
+        service, deviceKey) {
+
+        /* DNS TXT records has limitation on field lengths, as a result the 
+         * data may be split into up to 4 fields. 
+         * Need to join these up. */
+
+        let data1 = service['data1'];
+        if (service['data2']) {
+
+            const data2 = service['data2'];
+            data1 += data2;
+
+            if (service['data3']) {
+
+                const data3 = service['data3'];
+                data1 += data3;
+
+                if (service['data4']) {
+
+                    const data4 = service['data4'];
+                    data1 += data4;
+
+                }
+            }
+        }
+
+        /* Convert the string into a usable object. 
+         * Depending on the device setup, this may need to be decrypted first */
+        let data;
+        if (service.encrypt) {
+            /* If this is marked as encrypted, we need an API key to decrypt. 
+            */
+            if (deviceKey !== undefined) {
+                /* Should be able to decrypt this data.
+                 * Requires to get the IV from another field */
+                const iv = service['iv'];
+
+                data = this.decrypt(data1, deviceKey, iv);
+            } else {
+                this.log.error('Missing api_key for encrypted device %s', service.name);
+            }
+
+        } else {
+            data = data1;
+        }
+
+        this.log.debug('Data: %o', data);
+
+
+        /* Convert to a JSON object */
+        return (data ? JSON.parse(data) : undefined);
+    };
+
+    /**
+    * Method to perform an API call to the device. This handles aspects of wrapping
+    * the supplied data object with the result of the payload information. 
+    * This will always make http requests. 
+    * @param log the logger instance to use for log messages
+    * @param host the host to send the request to
+    * @param port the port to send the request to. 
+    * @param path the path to send the request to
+    * @param deviceId the device identifier
+    * @param data the data object containing the state to send to the device. The surrounding 
+    *             payload fields are all handled by this method.
+    * @param apiKey the device API key. This optional parameter should only be supplied when
+    *               performing an operation against a device which is not in DIY mode and so
+    *               requires encrypted payloads to be sent. 
+    */
+    async doApiCall(log, host, port, path, deviceId, data, apiKey) {
+
+        const payload = {
+            sequence: Date.now().toString(),
+            selfApikey: '123',
+            deviceid: deviceId,
+            data: JSON.stringify(data),
+            encrypt: false,
+        };
+
+
+        log.debug('Pre-encryption payload: %s', JSON.stringify(payload));
+
+        if (apiKey) {
+            /* if we have an API key, need to encrypt the data */
+            payload.encrypt = true;
+
+            const encryptionResult = encrypt(payload.data, apiKey);
+            payload.data = encryptionResult.data.toString('base64');
+            payload.iv = encryptionResult.iv.toString('base64');
+        }
+
+        let connectionHost = 'http://' + host;
+        if (port) {
+            connectionHost += ':' + port;
+        }
+
+        let webClient = request.createClient(connectionHost);
+        webClient.headers['Accept'] = 'application/json';
+        webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+        webClient.headers['Accept-Language'] = 'en-gb';
+
+        /* Return the promise for the request */
+        return webClient.post(path, payload);
+    }
+
+
+
+}

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -15,6 +15,8 @@ module.exports = class LanClient {
      */
     constructor(device, log) {
 
+        log.debug('Creating lan client for device %s', device.deviceid);
+
         this.device = device;
         this.log = log;
 
@@ -22,56 +24,128 @@ module.exports = class LanClient {
 
     }
 
+    /**
+     * Register internal listeners and make an initial query to attempt local discovery of the device. 
+     */
     start() {
+        this.log.debug('Starting lan client for device %s', this.device.deviceid);
+
         mdns.on('response', response => this.processDnsResponse(response));
 
         /* Send the initial query */
+        this.sendDnsQuery();
+    }
+
+    /**
+     * Sends a DNS query to discover devices
+     */
+    async sendDnsQuery() {
         mdns.query({
             questions: [
                 {
                     name: '_ewelink._tcp.local',
-                    // type: 'PTR'
-                    // name: 'MacBook.local',
                     type: 'TXT'
+                },
+                {
+                    name: 'eWeLink_' + this.device.deviceid + '.local',
+                    type: 'A'
+                },
+                {
+                    name: 'eWeLink_' + this.device.deviceid + '.local',
+                    type: 'SRV'
                 }
             ]
         });
     }
 
+    /**
+     * Close internal listeners for DNS responses. 
+     */
+    close() {
+        mdns.destroy();
+    }
 
+    /**
+     * Process a DNS response and look for this device. 
+     * 
+     * TODO: this could call back to update homebridge with updated
+     * device states
+     * 
+     * @param {*} response the DNS response from the mdns client
+     */
     processDnsResponse(response) {
+
+        //TODO: Need some way of determining when a device goes away
 
         /* find the item for the device */
         if (response.answers) {
             response.answers
-                .filter(value => value.name === this.deviceName && value.type === 'TXT')
+                .filter(value => value.name === this.deviceName)
                 .forEach(value => {
-                    this.log.debug('got a matching response for device %s: %o',
-                        this.device.deviceid, value)
+                    // this.log.debug('DNS Response: %o', response);
 
-                    let dataObject = {};
+                    if (value.type === 'TXT') {
+                        /* TXT records contain the state for the device */
 
-                    value.data.forEach(dataValue => {
-                        this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
+                        // this.log.debug('got a matching response for device %s: %o',
+                        //     this.device.deviceid, value)
 
-                        let bufferString = dataValue.toString('utf-8');
-                        let key = bufferString.substr(0, bufferString.indexOf('='));
+                        const processedDeviceResponse = Object.assign({}, value);
 
-                        dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
-                    });
+                        let dataObject = {};
 
-                    this.log.debug('DNS txt record for device %s is: %o',
-                        this.device.deviceid, dataObject);
+                        value.data.forEach(dataValue => {
+                            // this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
 
-                    
-                    /* Turn this TXT record into something usable for the state */
-                    const stateData = this.extractDataFromDnsService(dataObject, this.device.devicekey);
-                    this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
+                            let bufferString = dataValue.toString('utf-8');
+                            let key = bufferString.substr(0, bufferString.indexOf('='));
+
+                            dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
+                        });
+
+                        // this.log.debug('DNS txt record for device %s is: %o',
+                        //     this.device.deviceid, dataObject);
+                        processedDeviceResponse.data = dataObject;
+
+
+                        /* Turn this TXT record into something usable for the state */
+                        const stateData = this.extractDataFromDnsService(dataObject, this.device.devicekey);
+                        // this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
+                        processedDeviceResponse.data.state = stateData;
+
+                        this.localDevice = processedDeviceResponse;
+
+                        this.log.debug('LocalDevice state for %s is: %o', this.device.deviceid, this.localDevice);
+                    } else if (value.type === 'SRV') {
+                        /* A record contains the host details we need to invoke an API */
+                        this.log.debug('DNS SRV answer: %o', value);
+
+                        this.localDeviceHost = {
+                            host: value.data.target,
+                            port: value.data.port
+                        };
+
+                        this.log.debug('LocalDevice host for %s is: %o', this.device.deviceid, this.localDeviceHost);
+                    } else {
+                        this.log.debug('Unhandled device DNS answer: %o', value);
+                    }
                 });
-
         }
+
     }
 
+    /**
+     * Get the details of the local device state. 
+     */
+    getLocalDevice() {
+
+        /* If anything requests information on the local device, then
+         * kick off a new DNS query to ensure we are up to date 
+         */
+        this.sendDnsQuery();
+
+        return this.localDevice;
+    }
 
     /**
      * Decrypt the supplied data. 
@@ -126,7 +200,7 @@ module.exports = class LanClient {
             iv: iv,
         };
 
-    };
+    }
 
     /**
      * Extract the state data object from the MDNS service.
@@ -188,48 +262,42 @@ module.exports = class LanClient {
 
         /* Convert to a JSON object */
         return (data ? JSON.parse(data) : undefined);
-    };
+    }
 
     /**
     * Method to perform an API call to the device. This handles aspects of wrapping
     * the supplied data object with the result of the payload information. 
     * This will always make http requests. 
-    * @param log the logger instance to use for log messages
-    * @param host the host to send the request to
-    * @param port the port to send the request to. 
+    *  
     * @param path the path to send the request to
-    * @param deviceId the device identifier
     * @param data the data object containing the state to send to the device. The surrounding 
     *             payload fields are all handled by this method.
-    * @param apiKey the device API key. This optional parameter should only be supplied when
-    *               performing an operation against a device which is not in DIY mode and so
-    *               requires encrypted payloads to be sent. 
     */
-    async doApiCall(log, host, port, path, deviceId, data, apiKey) {
+    async doApiCall(path, data) {
 
         const payload = {
             sequence: Date.now().toString(),
             selfApikey: '123',
-            deviceid: deviceId,
+            deviceid: this.device.deviceid,
             data: JSON.stringify(data),
             encrypt: false,
         };
 
 
-        log.debug('Pre-encryption payload: %s', JSON.stringify(payload));
+        this.log.debug('Pre-encryption payload: %s', JSON.stringify(payload));
 
-        if (apiKey) {
+        if (this.localDevice.data.encrypt) {
             /* if we have an API key, need to encrypt the data */
             payload.encrypt = true;
 
-            const encryptionResult = encrypt(payload.data, apiKey);
+            const encryptionResult = this.encrypt(payload.data, this.device.devicekey);
             payload.data = encryptionResult.data.toString('base64');
             payload.iv = encryptionResult.iv.toString('base64');
         }
 
-        let connectionHost = 'http://' + host;
-        if (port) {
-            connectionHost += ':' + port;
+        let connectionHost = 'http://' + this.localDeviceHost.host;
+        if (this.localDeviceHost.port) {
+            connectionHost += ':' + this.localDeviceHost.port;
         }
 
         let webClient = request.createClient(connectionHost);
@@ -238,9 +306,81 @@ module.exports = class LanClient {
         webClient.headers['Accept-Language'] = 'en-gb';
 
         /* Return the promise for the request */
+        this.log.debug('Sending call to path: %s', path);
         return webClient.post(path, payload);
     }
 
+    /**
+     * Get the switch status of the current local device. 
+     * 
+     * @returns boolean of the switch status, or undefined if the device is not of the plug type
+     */
+    getSwitchStatus() {
 
+        this.log.debug('lanClient getSwitchStatus');
+
+        let result = undefined;
+        if (this.localDevice && this.localDevice.data.type === 'plug') {
+            result = this.localDevice.data.state.switch === 'on';
+        }
+
+        this.log.debug('lanClient getSwitchStatus result: %s', result);
+        return result;
+    }
+
+    /**
+     * 
+     * @param accessory the accessory being updated
+     * @param on boolean to indicate if the device should be sent an
+     *           'on' (true) or 'off' (false) state.
+     * @param callback the function to call after the update has been applied 
+     */
+    setSwitchStatus(accessory, on, callback) {
+
+        this.log.debug('Lan mode setSwitchStatus for %s to %o', accessory.displayName, on);
+  
+        const data = {
+            switch: (on ? 'on': 'off'),
+        };
+    
+        this.doApiCall('/zeroconf/switch', data)
+            .then(response => {
+                // this.log.debug('Device response: %o', response);
+
+                this.log.debug('Device response body: %o', response.body);
+
+                if (response.body.error === 0) {
+                    callback(null, on);
+                } else {
+                    callback('Error from the device API, code: ' + response.body.error);
+                }
+
+                
+            })
+            .catch(error => {
+                this.log.error('Error updating device: %s', error);
+                callback(error);
+            })
+    
+    }
+
+    /**
+     * Get the power state for a single outlet in a strip
+     * @param {int} outlet the outlet index to get the state for. This is zero indexed. 
+     * 
+     * @returns boolean of the switch status, or undefined if the device is not of the strip type
+     */
+    getStripOutletStatus(outlet) {
+
+        this.log.debug('lanClient getStripOutletStatus %s', outlet);
+
+        let result = undefined;
+        if (this.localDevice && this.localDevice.data.type === 'strip') {
+            result = this.localDevice.data.state.switches[outlet].switch === 'on';
+        }
+
+        this.log.debug('lanClient getStripOutletStatus result: %s', result);
+        return result;
+    }
 
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/howanghk/homebridge-ewelink"
   },
   "dependencies": {
+    "multicast-dns": "^7.2.2",
     "nonce": "^1.0.4",
     "request-json": "^0.6.2",
     "ws": "^3.3.2"


### PR DESCRIPTION
Relates to issue #41 .

This PR adds initial support for Lan mode, for devices which identify themselves as "plug". While there are references and code to support "strip" type devices, this is not currently working. I think this is something to do with the way that devices with multiple channels are currently handled (this is going to need a bit of refactoring to sort out I think). 

This only supports getting and setting the power state for a device, and has been tested against an S26 plug. 

This is currently hidden behind an additional configuration setting. To enable support for the lan client the following needs added to the platform configuration. 

`"experimentalLanClient": true`