### PR TITLE
A big one - Refactoring & WebSocket Client Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -139,6 +139,79 @@ The device is automatically reconfigured to turn off all options (power-on respo
     }
 ```
 
+### Advanced Configuration Modes
+
+There are a number of different mechanisms which can be used to communicate with Sonoff devices:
+1. A REST API, communicating with a server over the internet
+2. A WebSockets API, providing two-way communication with a server over the internet
+3. A LAN mode API, which uses a combination of DNS-SD and REST to communicate with devices directly without requiring internet access (although this is only supported by a small set of devices).
+
+The default configuration of this plugin will use the following:
+* REST API (1), for: 
+    * Login
+    * Listing devices
+    * Getting device state
+* WebSockets API (2), for:
+    * Sending device state updates
+    * Listening for device state notifications (e.g. if buttons are pressed directly on the device so homebridge is also updated)
+
+There are some feature flags available which allow for this behaviour to be changed. These are considered to be experimental and are included to allow wider testing than I alone am able to perform. 
+
+#### Web Socket Client Settings
+
+There are two settings available which impact the behaviour of the WebSocketClient. 
+
+The first is `experimentalWebSocketClient`, when set to true this will allow device state to be loaded using the WebSocket connection. Based on issue [#74](https://github.com/howanghk/homebridge-ewelink/issues/74) this is the preferred way to get status updates. After further testing this should become the default mode. 
+
+```json
+{
+        "platform" : "eWeLink",
+        "experimentalWebSocketClient": true,
+
+        "rest of platform": "config here"
+}
+```
+
+The second is `disableWebSocket`, when set to true this will disable the WebSocket client entirely. This is part of a future direction to allow the option to use Sonoff devices which support Lan mode without requiring a connection to the Ewelink servers. 
+
+```json
+{
+        "platform" : "eWeLink",
+        "disableWebSocket": true,
+
+        "rest of platform": "config here"
+}
+```
+
+#### Lan Client
+
+Some newer Sonoff devices, when on firmare versions 3.2 and later, have a Lan mode which allows the Ewelink app to control the devices without internet access. This does still however require this plugin to have at least logged in and loaded a device list from the internet to get the device keys for performing encryption and decryption.
+
+There are two forms that this client configuration can take:
+1. basic, which just takes a boolean to enable it. 
+```json
+    "experimentalLanClient": true
+```
+2. advanced, which takes in an object to allow extra settings to be enabled. This is only required when you have debug logging enabled and are trying to diagnose issues with the DNS-SD aspects of the plugin.  
+```json
+    "experimentalLanClient": {
+        "logDnsResponses": true
+    },
+```
+
+#### Fake Devices
+
+There is one last advanced setting which is useful for development purposes. I did not have a Sonoff fan controller, but by looking at the code which was already in this plugin it looked just to be a regular 4 switch device. The `fakeFan` setting can be used with a `deviceId` to tell the plugin that the 4 switch device should be identified as a fan. 
+
+```json
+{
+        "platform" : "eWeLink",
+        "fakeFan": "1000abcdef",
+
+        "rest of platform": "config here"
+}
+```
+
 ## A note on login session
 
 An authentication token is generated every time your device's app logs in to the eWeLink service.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ let nonce = require('nonce')();
 let crypto = require('crypto');
 
 let LanClient = require('./lib/sonoffLanModeApi');
+let WebSocketClient = require('./lib/webSocketClient');
 
 let wsc;
 let isSocketOpen = false;
@@ -2213,83 +2214,6 @@ eWeLink.prototype.getArguments = function () {
     args.romVersion = '11.1.2';
     args.appVersion = '3.5.3';
     return querystring.stringify(args);
-};
-
-/* WEB SOCKET STUFF */
-
-function WebSocketClient() {
-    this.number = 0; // Message number
-    this.autoReconnectInterval = 5 * 1000; // ms
-    this.pendingReconnect = false;
-}
-
-WebSocketClient.prototype.open = function (url) {
-    this.url = url;
-    this.instance = new WebSocket(this.url);
-    this.instance.on('open', () => {
-        this.onopen();
-    });
-
-    this.instance.on('message', (data, flags) => {
-        this.number++;
-        this.onmessage(data, flags, this.number);
-    });
-
-    this.instance.on('close', (e) => {
-        switch (e) {
-            case 1000: // CLOSE_NORMAL
-                // console.log("WebSocket: closed");
-                break;
-            default: // Abnormal closure
-                this.reconnect(e);
-                break;
-        }
-        this.onclose(e);
-    });
-    this.instance.on('error', (e) => {
-        switch (e.code) {
-            case 'ECONNREFUSED':
-                this.reconnect(e);
-                break;
-            default:
-                this.onerror(e);
-                break;
-        }
-    });
-};
-WebSocketClient.prototype.send = function (data, option) {
-    try {
-        this.instance.send(data, option);
-    } catch (e) {
-        this.instance.emit('error', e);
-    }
-};
-WebSocketClient.prototype.reconnect = function (e) {
-    // console.log(`WebSocketClient: retry in ${this.autoReconnectInterval}ms`, e);
-
-    if (this.pendingReconnect) return;
-    this.pendingReconnect = true;
-
-    this.instance.removeAllListeners();
-
-    let platform = this;
-    setTimeout(function () {
-        platform.pendingReconnect = false;
-        console.log("WebSocketClient: reconnecting...");
-        platform.open(platform.url);
-    }, this.autoReconnectInterval);
-};
-WebSocketClient.prototype.onopen = function (e) {
-    // console.log("WebSocketClient: open", arguments);
-};
-WebSocketClient.prototype.onmessage = function (data, flags, number) {
-    // console.log("WebSocketClient: message", arguments);
-};
-WebSocketClient.prototype.onerror = function (e) {
-    console.log("WebSocketClient: error", arguments);
-};
-WebSocketClient.prototype.onclose = function (e) {
-    // console.log("WebSocketClient: closed", arguments);
 };
 
 //////////////

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function eWeLink(log, config, api) {
 
                         platform.log("Connecting to the WebSocket API at [%s]", url);
 
-                        platform.wsc = new WebSocketClient(platform.log);
+                        platform.wsc = new WebSocketClient(platform.log, platform.config);
 
                         platform.wsc.open(url);
 
@@ -202,38 +202,6 @@ function eWeLink(log, config, api) {
                                     }, json.config.hbInterval * 1000);
                                 }
                             }
-
-                        };
-
-                        platform.wsc.onopen = function (e) {
-
-                            platform.isSocketOpen = true;
-
-                            // We need to authenticate upon opening the connection
-
-                            let time_stamp = new Date() / 1000;
-                            let ts = Math.floor(time_stamp);
-
-                            // Here's the eWeLink payload as discovered via Charles
-                            let payload = {};
-                            payload.action = "userOnline";
-                            payload.userAgent = 'app';
-                            payload.version = 6;
-                            payload.nonce = '' + nonce();
-                            payload.apkVesrion = "1.8";
-                            payload.os = 'ios';
-                            payload.at = config.authenticationToken;
-                            payload.apikey = config.apiKey;
-                            payload.ts = '' + ts;
-                            payload.model = 'iPhone10,6';
-                            payload.romVersion = '11.1.2';
-                            payload.sequence = platform.getSequence();
-
-                            let string = JSON.stringify(payload);
-
-                            platform.log('Sending login request [%s]', string);
-
-                            platform.wsc.send(string);
 
                         };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,306 @@
+const EventEmitter = require('events');
+
+const EwelinkApi = require('./ewelinkApi');
+const LanClient = require('./sonoffLanModeApi');
+const WebSocketClient = require('./webSocketClient');
+
+/**
+ * Class that aims to be a single point of interaction between the platform and
+ * APIs for getting and setting details about devices. 
+ * 
+ * This aims to act as an abstraction point so that the platform does not need to 
+ * know if the LAN, HTTP or WebSockets APIs are being used. 
+ */
+module.exports = class ApiClient {
+
+    /**
+     * Create a new Api
+     * @param {*} log the logger instance to use for log messages
+     * @param {*} config the plugin configuration
+     */
+    constructor(log, config) {
+
+        /* Set parameters to fields in this class */
+        this.log = log;
+        this.config = config;
+
+        /* Configure the Ewelink API Client */
+        log.debug("Initialising EwelinkApi");
+        this.ewelinkApiClient = new EwelinkApi(log, config);
+        this.ewelinkApiClient.addListener(() => {
+            /* After a login event, if we have an existing websocket connection we need 
+             * to close it and reconnect */
+            if (this.wsc && this.wsc.isSocketOpen()) {
+                this.wsc.instance.terminate();
+                this.wsc.onclose();
+                this.wsc.reconnect();
+            }
+
+            if (!this.wsc) {
+                /* If the websocket client does not exist, load the host and 
+                * initialise it 
+                */
+                this.ewelinkApiClient.getWebSocketHost()
+                    .then((domain) => {
+                        this.log.debug('WebSocket domain: %s', domain);
+                        this._initWebSocketClient();
+                    }).catch(() => {
+                        this.log.error('Failed to load web socket host');
+                    });
+            }
+
+            /* Pass on the login event to our listeners */
+            this.eventEmitter.emit('login');
+        });
+
+        /* Configure the LAN client, if the feature is enabled  */
+        if (config['experimentalLanClient']) {
+            log.debug('Configuring LAN Client');
+            this.lanClient = new LanClient(log);
+            this.lanClient.start();
+        }
+
+        /* Add an event emmitter for login events */
+        this.eventEmitter = new EventEmitter();
+
+    }
+
+    /**
+     * Initialise the web socket client. 
+     */
+    _initWebSocketClient() {
+        // We have our devices, now open a connection to the WebSocket API
+
+        const url = 'wss://' + this.config['webSocketApi'] + ':8080/api/ws';
+        this.log.info('Connecting to the WebSocket API at [%s]', url);
+
+        this.wsc = new WebSocketClient(this.log, this.config);
+        this.wsc.open(url);
+
+        /* Configure listeners */
+        this.wsc.onmessage = (message) => {
+
+            // Heartbeat response can be safely ignored
+            if (message == 'pong') {
+                return;
+            }
+
+            this.log.debug('WebSocket messge received: %o', message);
+
+            //TODO: Check IMPL
+
+            if (message.action && (message.action === 'update' || message.action === 'sysmsg')) {
+                /* Change in device state */
+                this.eventEmitter.emit('state', message);
+            }
+        };
+    }
+
+    /**
+     * Add a listener function to be called when a login event occurs
+     * @param {function} funct the function to be called when events occur.
+     */
+    addLoginEventListener(funct) {
+        this.eventEmitter.addListener('login', funct);
+    }
+
+    /**
+     * Add a listener to be called when the state of a device changes. 
+     * @param {function} funct the function to be called when events occur. 
+     */
+    addDeviceStateListener(funct) {
+        this.eventEmitter.addListener('state', funct);
+    }
+
+    /**
+     * Method to perform any additional configuration required before login can be performed. 
+     * 
+     * At present, this checks if there is a country code specified and resolves the correct 
+     * region, updating the api host configuration. 
+     */
+    init() {
+
+        return new Promise((resolve, reject) => {
+            // Resolve region if countryCode is provided
+            if (this.config['countryCode']) {
+
+                this.ewelinkApiClient.getRegion()
+                    .then(region => {
+
+                        this.log.info('Region is: %s', region);
+
+                        /* Update the API host */
+                        let idx = this.config.apiHost.indexOf('-');
+                        if (idx == -1) {
+                            this.log.warning('Received region [%s]. However we cannot construct the new API host url.', region);
+
+                        } else {
+                            let newApiHost = region + this.config.apiHost.substring(idx);
+                            if (this.config.apiHost != newApiHost) {
+                                this.log.debug("Received region [%s], updating API host to [%s].", region, newApiHost);
+                                this.config.apiHost = newApiHost;
+                            }
+                        }
+                        resolve();
+
+                    }).catch(err => {
+                        this.log.error('Failed to get region: %s', err);
+                        reject('Failed to get region information: ' + err);
+                    })
+            } else {
+                resolve();
+            }
+        });
+    }
+
+    /**
+     * Get the current status for an accessory device. 
+     * @param {*} accessory 
+     */
+    async getDeviceStatus(accessory) {
+
+
+
+        /* Extract out the deviceId */
+        let deviceId = accessory.context.deviceId;
+
+        if (accessory.context.switches > 1) {
+            deviceId = deviceId.replace("CH" + accessory.context.channel, "");
+        }
+
+        let deviceStatus = undefined;
+
+        if (this.config.experimentalLanClient && this.lanClient) {
+            try {
+                deviceStatus = await this.lanClient.getDeviceStatus(deviceId);
+
+                //TODO: FINISH IMPLEMENTING
+                // let localDevice = undefined;
+                // if (accessory.context.lanClient && 
+                //         accessory.context.lanClient.getLocalDevice) {
+                //     /* Only get the local device state if there is a lan client and it
+                //      * has the expected function. 
+                //      * This latter check seems to be required when a device is partially
+                //      * restored and homebridge tries to get the state before it is fully
+                //      * set up. 
+                //      */
+                //     localDevice = accessory.context.lanClient.getLocalDevice();
+                // }
+                    
+                // let status = undefined;
+                // if (localDevice) {
+                //     if (localDevice.data.type === 'plug') {
+                //         status = accessory.context.lanClient.getSwitchStatus();
+                //     } else if (localDevice.data.type === 'strip') {
+                //         status = accessory.context.lanClient.getStripOutletStatus(
+                //             accessory.context.channel);
+                //     }
+                // } 
+
+            } catch (error) {
+                //TODO: implement
+                this.log.error('Error loading lan client: %s', error);
+            }
+        }
+
+        if (deviceStatus === undefined) {
+            if (this.config.experimentalWebSocketClient) {
+                if (!(this.wsc && this.wsc.isSocketOpen && this.wsc.isSocketOpen())) {
+                    accessory.reachable = false;
+                    throw new Error('websocket not ready while obtaining status for your device');
+                }
+
+                deviceStatus = await this.wsc.getDeviceStatus(deviceId);
+            } else {
+                deviceStatus = await this.ewelinkApiClient.getDeviceStatus(deviceId);
+
+                if (deviceStatus.online !== true) {
+                    accessory.reachable = false;
+                    this.log("Device [%s] was reported to be offline by the API", accessory.displayName);
+                    throw new Error('API reported that [' + device.name + '] is not online');
+                }
+            }
+        }
+
+        return deviceStatus;
+
+    }
+
+    /**
+     * Set the new status params for a device. 
+     * @param {*} accessory the accessory to set the status for
+     * @param {*} statusParams the new device status params
+     */
+    async updateDeviceStatus(accessory, statusParams) {
+
+        /* Extract out the deviceId */
+        let deviceId = accessory.context.deviceId;
+        if (accessory.context.switches > 1) {
+            deviceId = deviceId.replace("CH" + accessory.context.channel, "");
+        }
+
+        //TODO: Detect if we can update this type of device through the lan client also
+
+        if (this.config.experimentalLanClient && this.lanClient) {
+            //TODO: IMPLEMENT
+            // let localDevice = undefined;
+            //     if (accessory.context.lanClient && accessory.context.lanClient.getLocalDevice) {
+            //         /* Try to get the local device state if a lan client exists */
+            //         localDevice = accessory.context.lanClient.getLocalDevice();
+            //     }
+                
+            //     if(localDevice && localDevice.data.type === 'plug') {
+            //         /* We can do a local device call for this */
+            //         accessory.context.lanClient.setSwitchStatus(
+            //             accessory, value, callback);
+            //     }
+        } else {
+            /* Websockets are the default option here, although there is an HTTP API 
+             * too. */
+            return this.wsc.updateDeviceStatus(deviceId, statusParams);
+        }
+    }
+
+    /**
+     * List the devices for the currently session. 
+     * 
+     * Currently this will only use the HTTP API. This information is not available via
+     * web sockets, but could potentially also include devices that are in DIY mode via
+     * the LAN client. 
+     * (FUTURE ENHANCEMENT)
+     * 
+     * 
+     * @returns a promise for the get request. The resolve result will be the device list 
+     *          from the API. Any other error case will use the rejection call. 
+     */
+    listDevices() {
+
+        /* TODO: Need to wrap this so we can peek at it before resolving, 
+                 so we can set device keys in the lan client */
+
+        return new Promise((resolve, reject) => {
+            this.ewelinkApiClient.listDevices()
+                .then(devices => {
+                    /* Add the device keys to the lan client */
+                    if (this.lanClient) {
+                        devices.forEach(device => 
+                            this.lanClient.addDeviceKey(device.deviceid, device.devicekey));
+                    }
+
+                    resolve(devices);
+                }).catch(err => reject(err));
+        });
+    }
+
+    /**
+     * Login to the Ewelink API
+     * 
+     * @returns a promise. The resolve callback will be used when a valid 
+     *          authentication token it returned by the API. The return type will be an 
+     *          object with two fields, authenticationToken and apiKey. 
+     *          The reject callback will be used for all error conditions. 
+     */
+    login() {
+        return this.ewelinkApiClient.login();
+    }
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -197,8 +197,16 @@ module.exports = class ApiClient {
                 //     }
                 // } 
 
+                this.log.debug('Lan Client device status: %o', deviceStatus);
+
+                if (!(deviceStatus && deviceStatus.params)) {
+                    /* Either didn't get a device status, or the value does not have the "params"
+                     * section we need for getting status details. 
+                     */
+                    deviceStatus = undefined;
+                }
+
             } catch (error) {
-                //TODO: implement
                 this.log.error('Error loading lan client: %s', error);
             }
         }
@@ -220,6 +228,10 @@ module.exports = class ApiClient {
                     throw new Error('API reported that [' + device.name + '] is not online');
                 }
             }
+        }
+
+        if (deviceStatus) {
+            this.log.debug('Device params: %o', deviceStatus.params);
         }
 
         return deviceStatus;

--- a/lib/api.js
+++ b/lib/api.js
@@ -36,7 +36,7 @@ module.exports = class ApiClient {
                 this.wsc.reconnect();
             }
 
-            if (!this.wsc) {
+            if (!this.wsc && !this.config.disableWebSocket) {
                 /* If the websocket client does not exist, load the host and 
                 * initialise it 
                 */
@@ -54,13 +54,21 @@ module.exports = class ApiClient {
         });
 
         /* Configure the LAN client, if the feature is enabled  */
-        if (config['experimentalLanClient']) {
+        if (config.experimentalLanClient) {
             log.debug('Configuring LAN Client');
-            this.lanClient = new LanClient(log);
-            this.lanClient.start();
+            this.lanClient = new LanClient(log, config);
+            this.lanClient.addDeviceStateListener((message => {
+
+                this.log.debug('Lan message received: %o', message);
+
+                if (message.action && (message.action === 'update' || message.action === 'sysmsg')) {
+                    /* Change in device state */
+                    this.eventEmitter.emit('state', message);
+                }
+            }));
         }
 
-        /* Add an event emmitter for login events */
+        /* Add an event emmitter for events */
         this.eventEmitter = new EventEmitter();
 
     }
@@ -266,10 +274,14 @@ module.exports = class ApiClient {
             //         accessory.context.lanClient.setSwitchStatus(
             //             accessory, value, callback);
             //     }
-        } else {
+
+            return this.lanClient.updateDeviceStatus(accessory, statusParams);
+        } else if (this.wsc) {
             /* Websockets are the default option here, although there is an HTTP API 
              * too. */
             return this.wsc.updateDeviceStatus(deviceId, statusParams);
+        } else {
+            throw new Error("No supported update mechanism found. ")
         }
     }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,119 @@
+const EventEmitter = require('events');
+
+/**
+ * A very basic object which acts as a cache. 
+ * 
+ * Items added to the cache will have a TTL applied to them automatically. 
+ */
+module.exports = class Cache {
+
+    /**
+     * Create a new Cache
+     * @param {*} log the logger instance to use for log messages
+     * @param {number} defaultCacheDuration the default cache duration (in milliseconds) to use 
+     *                                      for items added to the cache. 
+     */
+    constructor(log, defaultCacheDuration = 500) {
+
+        /* Set constructor params */
+        this.log = log;
+        this.defaultCacheDuration = defaultCacheDuration;
+
+        /* Map we will use to hold the cache contents */
+        this.cacheMap = new Map();
+
+        /* Map of cache key to the timer for it's deletion. 
+         * This will be used so that, when a cache key is inserted again, 
+         * any previous timer will be cleared */
+        this.timerMap = new Map();
+
+        /* Add an event emmitter for events */
+        this.eventEmitter = new EventEmitter();
+
+    }
+
+    /**
+     * Add a listener to be called when a key is expired from the cache. 
+     * @param {function} funct the function to be called when events occur. 
+     *                         This will be supplied the deviceId as a parameter. 
+     */
+    addCacheExpiryListener(funct) {
+        this.eventEmitter.addListener('expiry', funct);
+    }
+
+    /**
+     * Get an item from the cache map.
+     * @param {*} key the key to lookup the value for. 
+     * @returns the value from the cache, or undefined if there is no value held. 
+     */
+    get(key) {
+        return this.cacheMap.get(key);
+    }
+
+    /**
+     * Get the keys that are currently held in the cache.
+     * 
+     * @returns an iterable of keys in the cache. 
+     */
+    keys() {
+        this.cacheMap.keys();
+    }
+
+    /**
+     * Add an item to the cache. 
+     * 
+     * This will be automatically removed from the cache after the cacheDuration. If a 
+     * cache duration is not supplied, the default value of 500 will be used. 
+     * 
+     * @param {*} key the key to store the value against
+     * @param {*} value the value to store. 
+     * @param {number} cacheDuration (optional) the duration to cache the item for, in milliseconds. 
+     */
+    set(key, value, cacheDuration = this.defaultCacheDuration) {
+
+        this._clearTimer(key);
+
+        /* Add the item to the cache */
+        this.cacheMap.set(key, value);
+
+        /* Set a timer to remove the item from the cache.
+         * This timerId is added to a map in case we need to cancel it early */
+        const timerId = setTimeout(() => {
+            /* Delete the item */
+            let removed = this.cacheMap.delete(key);
+
+            /* If the item was removed by this timer, send a notification event */
+            if (removed) {
+                this.eventEmitter.emit('expiry', key);
+            }
+        }, cacheDuration);
+
+        this.timerMap.set(key, timerId);
+
+    }
+
+    /**
+     * Delete an item from the cache.
+     * @param {*} key the key for the item to remove from the cache
+     */
+    delete(key) {
+        /* Remove the item from the cache */
+        this.cacheMap.delete(key);
+
+        /* Clear any timers for the item */
+        this._clearTimer(key);
+    }
+
+    /**
+     * Clear any timers that exist for a cache key. 
+     * @param {*} key the cache key to clear the timers for. 
+     */
+    _clearTimer(key) {
+        /* If there are any existing timers for the key, clear them */
+        let existingTimerId = this.timerMap.get(key);
+        if (existingTimerId) {
+            clearTimeout(existingTimerId);
+        }
+    }
+
+}

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -1,7 +1,8 @@
-let request = require('request-json');
-let crypto = require('crypto');
+const request = require('request-json');
+const crypto = require('crypto');
 const querystring = require('querystring');
-const { resolve } = require('path');
+
+const EventEmitter = require('events');
 
 /**
  * Class exposing methods to interact with Ewelink through their HTTP API.
@@ -42,6 +43,18 @@ module.exports = class EwelinkApi {
 
         this.config = config;
 
+
+        /* Add an event emmitter for login events */
+        this.loginEventEmitter = new EventEmitter();
+
+    }
+
+    /**
+     * Add a listener function to be called when a login event occurs
+     * @param {function} funct 
+     */
+    addListener(funct) {
+        this.loginEventEmitter.addListener('login', funct);
     }
 
     /**
@@ -133,8 +146,14 @@ module.exports = class EwelinkApi {
                 } else if (result.body.error && result.body.error != 0) {
                     let response = JSON.stringify(result.body);
                     this.log.error('An error was encountered while requesting a list of devices. Response was [%s]', response);
-                    if (result.body.error === '401') {
-                        this.log.error('Verify that you have the correct authenticationToken specified in your configuration. The currently-configured token is [%s]', platform.authenticationToken);
+                    /* TODO: Consider - different calls to this API in the previous implementation handled this
+                     *     differently. One just logged, one triggered a new login attempt.
+                     */
+                    // if (result.body.error === '401') {
+                    //     this.log.error('Verify that you have the correct authenticationToken specified in your configuration. The currently-configured token is [%s]', platform.authenticationToken);
+                    // }
+                    if ([401, 402].indexOf(parseInt(result.body.error)) !== -1) {
+                        this.login();
                     }
                     throw new Error('API returned error response');
                 } else {
@@ -263,6 +282,10 @@ module.exports = class EwelinkApi {
                             apiKey: this.apiKey
                         };
 
+                        /* Tell listeners a login event has occured. */
+                        this.loginEventEmitter.emit('login');
+
+                        /* Return the result */
                         this.log.debug('Login returning: %o', returnObject);
 
                         return returnObject;

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -125,53 +125,53 @@ module.exports = class EwelinkApi {
      * @returns a promise for the get request. The resolve result will be the device list 
      *          from the API. Any other error case will use the rejection call. 
      */
-    async listDevices() {
+    listDevices() {
 
-        /* We can only make calls if we have an authentication token */
-        if (!this.authenticationToken) {
-            throw new Error('No authentication token found. ' +  
-                'This is likely caused by attempting to get devices before logging in');
-        }
+        return new Promise((resolve, reject) => {
+            /* We can only make calls if we have an authentication token */
+            if (!this.authenticationToken) {
+                throw new Error('No authentication token found. ' +  
+                    'This is likely caused by attempting to get devices before logging in');
+            }
 
-        const url = 'https://' + this.config['apiHost'];
+            const url = 'https://' + this.config['apiHost'];
 
-        this.log.debug('Requesting a list of devices from eWeLink HTTPS API at [%s]', url);
+            this.log.debug('Requesting a list of devices from eWeLink HTTPS API at [%s]', url);
 
-        
-        let webClient = request.createClient(url);
-        webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
-        return await webClient.get('/api/user/device?' + this.getArgumentQueryString())
-            .then(result => {
+            const webClient = request.createClient(url);
+            webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
+            webClient.get('/api/user/device?' + this.getArgumentQueryString())
+                .then(result => {
 
-                if (!result.body) {
+                    if (!result.body) {
 
-                    const message = 'An error was encountered while requesting a list of devices. No data in response.';
+                        const message = 'An error was encountered while requesting a list of devices. No data in response.';
 
-                    this.log.error(message);
-                    throw new Error(message);
-                } else if (result.body.error && result.body.error != 0) {
-                    let response = JSON.stringify(result.body);
-                    this.log.error('An error was encountered while requesting a list of devices. Response was [%s]', response);
-                    /* TODO: Consider - different calls to this API in the previous implementation handled this
-                     *     differently. One just logged, one triggered a new login attempt.
-                     */
-                    // if (result.body.error === '401') {
-                    //     this.log.error('Verify that you have the correct authenticationToken specified in your configuration. The currently-configured token is [%s]', platform.authenticationToken);
-                    // }
-                    if ([401, 402].indexOf(parseInt(result.body.error)) !== -1) {
-                        this.login();
+                        this.log.error(message);
+                        reject(message);
+                    } else if (result.body.error && result.body.error != 0) {
+                        let response = JSON.stringify(result.body);
+                        this.log.error('An error was encountered while requesting a list of devices. Response was [%s]', response);
+                        /* TODO: Consider - different calls to this API in the previous implementation handled this
+                        *     differently. One just logged, one triggered a new login attempt.
+                        */
+                        // if (result.body.error === '401') {
+                        //     this.log.error('Verify that you have the correct authenticationToken specified in your configuration. The currently-configured token is [%s]', platform.authenticationToken);
+                        // }
+                        if ([401, 402].indexOf(parseInt(result.body.error)) !== -1) {
+                            this.login();
+                        }
+                        reject('API returned error response');
+                    } else {
+                        // this.log.debug('Returning device list: %o', result.body.devicelist);
+                        resolve(result.body.devicelist);
                     }
-                    throw new Error('API returned error response');
-                } else {
-                    // this.log.debug('Returning device list: %o', result.body.devicelist);
-                    return (result.body.devicelist);
-                }
 
-            }).catch(err => {
-                this.log.error('An error was encountered while requesting a list of devices. Error was [%s]', err);
-                
-                throw new Error(err);
-            });
+                }).catch(err => {
+                    this.log.error('An error was encountered while requesting a list of devices. Error was [%s]', err);
+                    reject(err);
+                });
+        });
     }
 
     /**
@@ -216,94 +216,94 @@ module.exports = class EwelinkApi {
      *          object with two fields, authenticationToken and apiKey. 
      *          The reject callback will be used for all error conditions. 
      */
-    async login() {
+    login() {
 
-        /* Check the configuration is good */
-        if (!this.config.phoneNumber && !this.config.email || !this.config.password || !this.config.imei) {
-            const message = 'phoneNumber / email / password / imei not found in config, skipping login';
-            this.log.error(message);
-            throw new Error(message);
-        } else {
-            /* Configuration is good, try to make the API call */
+        return new Promise((resolve, reject) => {
 
-            /* Setup the Object with the API request data */
-            let data = {};
-            if (this.config.phoneNumber) {
-                data.phoneNumber = this.config.phoneNumber;
-            } else if (this.config.email) {
-                data.email = this.config.email;
-            }
-            data.password = this.config.password;
+            /* Check the configuration is good */
+            if ((!this.config.phoneNumber && !this.config.email) || 
+                    !this.config.password || 
+                    !this.config.imei) {
+                const message = 'phoneNumber / email / password / imei not found in config, skipping login';
+                this.log.error(message);
+                reject(message);
+            } else {
+                /* Configuration is good, try to make the API call */
 
-            /* Setup the fields which are common to all API calls */
-            data = this.populateCommonApiRequestFields(data);
+                /* Setup the Object with the API request data */
+                let data = {};
+                if (this.config.phoneNumber) {
+                    data.phoneNumber = this.config.phoneNumber;
+                } else if (this.config.email) {
+                    data.email = this.config.email;
+                }
+                data.password = this.config.password;
+
+                /* Setup the fields which are common to all API calls */
+                data = this.populateCommonApiRequestFields(data);
 
 
-            const json = JSON.stringify(data);
-            this.log.debug('Sending login request with user credentials: %s', json);
+                const json = JSON.stringify(data);
+                this.log.debug('Sending login request with user credentials: %s', json);
 
-            let sign = this.getSignature(json);
-            this.log.debug('Login signature: %s', sign);
+                const sign = this.getSignature(json);
+                this.log.debug('Login signature: %s', sign);
 
-            let webClient = request.createClient('https://' + this.config.apiHost);
-            webClient.headers['Authorization'] = 'Sign ' + sign;
-            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
-            await webClient.post('/api/user/login', data)
-                .then(result => {
+                const webClient = request.createClient('https://' + this.config.apiHost);
+                webClient.headers['Authorization'] = 'Sign ' + sign;
+                webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+                webClient.post('/api/user/login', data)
+                    .then(result => {
 
-                    // If we receive 301 error, switch to new region and try again
-                    if (result.body.error && result.body.error == 301 && result.body.region) {
-                        let idx = this.config.apiHost.indexOf('-');
-                        if (idx == -1) {
-                            this.log.error('Received new region [%s]. However we cannot construct the new API host url.', body.region);
-                            throw new Error('Received new region, however we cannot construct the new API host url.');
-                        } else {
-                            let newApiHost = result.body.region + this.config.apiHost.substring(idx);
-                            if (this.config.apiHost != newApiHost) {
-                                this.log('Received new region [%s], updating API host to [%s].', result.body.region, newApiHost);
-                                this.config.apiHost = newApiHost;
-                                this.login()
-                                    .then(loginResult => {
-                                        return loginResult
-                                    }).catch(err => {
-                                        throw new Error(err)
-                                    });
+                        // If we receive 301 error, switch to new region and try again
+                        if (result.body.error && result.body.error == 301 && result.body.region) {
+                            let idx = this.config.apiHost.indexOf('-');
+                            if (idx == -1) {
+                                this.log.error('Received new region [%s]. However we cannot construct the new API host url.', body.region);
+                                reject('Received new region, however we cannot construct the new API host url.');
+                            } else {
+                                let newApiHost = result.body.region + this.config.apiHost.substring(idx);
+                                if (this.config.apiHost != newApiHost) {
+                                    this.log('Received new region [%s], updating API host to [%s].', result.body.region, newApiHost);
+                                    this.config.apiHost = newApiHost;
+                                    this.login()
+                                        .then(loginResult => resolve(loginResult))
+                                        .catch(err => reject(err));
+                                }
                             }
+                        } else if (!result.body.at) {
+                            let response = JSON.stringify(result.body);
+                            this.log.error('Server did not response with an authentication token. Response was [%s]', response);
+                            reject('Server did not response with an authentication token.')
+                        } else {
+                            /* Successful login and body looks as expected, return the authentication token (and set it locally) */
+                            this.log.debug('Authentication token received [%s]', result.body.at);
+                            this.log.debug('Login response body: %o', result.body);
+                            this.authenticationToken = result.body.at;
+                            this.config.authenticationToken = this.authenticationToken;
+                            this.apiKey = result.body.user.apikey;
+                            this.config.apiKey = this.apiKey;
+
+                            let returnObject = {
+                                authenticationToken: this.authenticationToken,
+                                apiKey: this.apiKey
+                            };
+
+                            /* Tell listeners a login event has occured. */
+                            this.loginEventEmitter.emit('login');
+
+                            /* Return the result */
+                            this.log.debug('Login returning: %o', returnObject);
+
+                            resolve(returnObject);
                         }
-                    } else if (!result.body.at) {
-                        let response = JSON.stringify(result.body);
-                        this.log.error('Server did not response with an authentication token. Response was [%s]', response);
-                        throw new Error('Server did not response with an authentication token.')
-                    } else {
-                        /* Successful login and body looks as expected, return the authentication token (and set it locally) */
-                        this.log.debug('Authentication token received [%s]', result.body.at);
-                        this.log.debug('Login response body: %o', result.body);
-                        this.authenticationToken = result.body.at;
-                        this.config.authenticationToken = this.authenticationToken;
-                        this.apiKey = result.body.user.apikey;
-                        this.config.apiKey = this.apiKey;
 
-                        let returnObject = {
-                            authenticationToken: this.authenticationToken,
-                            apiKey: this.apiKey
-                        };
-
-                        /* Tell listeners a login event has occured. */
-                        this.loginEventEmitter.emit('login');
-
-                        /* Return the result */
-                        this.log.debug('Login returning: %o', returnObject);
-
-                        return returnObject;
-                    }
-
-
-                }).catch(err => {
-                    this.log.error('An error was encountered while logging in. Error was [%s]', err);
-                    throw new Error('An error was encountered while logging in.');
-                });
-
-        }
+                    }).catch(err => {
+                        this.log.error('An error was encountered while logging in. Error was [%s]', err);
+                        reject('An error was encountered while logging in.');
+                    });
+            }
+        });
     }
 
     /**
@@ -313,48 +313,51 @@ module.exports = class EwelinkApi {
      * @returns a promise. The resolve callback will be called with the region code. 
      *          Any error condition will call the reject callback with an error message. 
      */
-    async getRegion(countryCode) {
+     getRegion(countryCode) {
 
-        /* Set the arguments specific to this API call */
-        var data = {
-            country_code: countryCode
-        };
-        /* Set the arguments that apply to all API calls */
-        data = this.populateCommonApiRequestFields(data);
+        return new Promise((resolve, reject) => {
+
+            /* Set the arguments specific to this API call */
+            var data = {
+                country_code: countryCode
+            };
+            /* Set the arguments that apply to all API calls */
+            data = this.populateCommonApiRequestFields(data);
 
 
-        let query = querystring.stringify(data);
-        this.log.debug('getRegion query: %s', query);
+            let query = querystring.stringify(data);
+            this.log.debug('getRegion query: %s', query);
 
-        /* Create a signature for the request */
-        const dataToSign = Object.keys(data)
-            .sort((a, b) => b.localeCompare(a))
-            .map(key => key + '=' + data[key])
-            .join('&');
+            /* Create a signature for the request */
+            const dataToSign = Object.keys(data)
+                .sort((a, b) => b.localeCompare(a))
+                .map(key => key + '=' + data[key])
+                .join('&');
 
-        const signature = this.getSignature(dataToSign);
-        this.log.debug('getRegion signature: %s', signature);
+            const signature = this.getSignature(dataToSign);
+            this.log.debug('getRegion signature: %s', signature);
 
-        
-        let webClient = request.createClient('https://api.coolkit.cc:8080');
-        webClient.headers['Authorization'] = 'Sign ' + signature;
-        webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+            
+            let webClient = request.createClient('https://api.coolkit.cc:8080');
+            webClient.headers['Authorization'] = 'Sign ' + signature;
+            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
 
-        return await webClient.get('/api/user/region?' + query)
-            .then(result => {
-                if (!result.body.region) {
-                    let response = JSON.stringify(result.body);
-                    this.log.error('Server did not response with a region. Response was [%s]', response);
-                    throw new Error('Server did not response with a region.');
-                } else {
-                    this.log.debug('Got region: %s', result.body.region);
-                    return result.body.region;
-                }
+            webClient.get('/api/user/region?' + query)
+                .then(result => {
+                    if (!result.body.region) {
+                        let response = JSON.stringify(result.body);
+                        this.log.error('Server did not response with a region. Response was [%s]', response);
+                        reject('Server did not response with a region.');
+                    } else {
+                        this.log.debug('Got region: %s', result.body.region);
+                        resolve(result.body.region);
+                    }
 
-            }).catch(err => {
-                this.log.error('An error was encountered while getting region. Error was [%s]', err);
-                throw new Error('An error was encountered while getting region.');
-            });
+                }).catch(err => {
+                    this.log.error('An error was encountered while getting region. Error was [%s]', err);
+                    reject('An error was encountered while getting region.');
+                });
+        });
 
     }
 
@@ -364,38 +367,41 @@ module.exports = class EwelinkApi {
      * @returns a promise. The resolve callback will be called with the websocket host. 
      *          Any error condition will call the reject callback with an error message. 
      */
-    async getWebSocketHost() {
+    getWebSocketHost() {
 
-        /* Set the request data that is specific to this API invocation */
-        let data = {
-            accept: 'mqtt,ws'
-        };
+        return new Promise((resolve, reject) => {
 
-        /* Set the arguments that apply to all API calls */
-        data = this.populateCommonApiRequestFields(data);
-        
-        
-        let webClient = request.createClient('https://' + this.config.apiHost.replace('-api', '-disp'));
-        webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
-        webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
-        webClient.post('/dispatch/app', data)
-            .then(result => {
+            /* Set the request data that is specific to this API invocation */
+            let data = {
+                accept: 'mqtt,ws'
+            };
 
-                if (!result.body.domain) {
-                    /* Response body did not contain the field we expected */
-                    let response = JSON.stringify(body);
-                    this.log.error('Server did not response with a websocket host. Response was [%s]', response);
-                    throw new Error('Server did not response with a websocket host.');
-                } else {
-                    this.log.debug('WebSocket host received [%s]', result.body.domain);
-                    this.config['webSocketApi'] = result.body.domain;
-                    
-                    return result.body.domain;
-                }
-            }).catch(err => {
-                this.log.error('An error was encountered while getting websocket host. Error was [%s]', err);
-                throw new Error('An error was encountered while getting websocket host.');
-            });
+            /* Set the arguments that apply to all API calls */
+            data = this.populateCommonApiRequestFields(data);
+            
+            
+            let webClient = request.createClient('https://' + this.config.apiHost.replace('-api', '-disp'));
+            webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
+            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+            webClient.post('/dispatch/app', data)
+                .then(result => {
+
+                    if (!result.body.domain) {
+                        /* Response body did not contain the field we expected */
+                        let response = JSON.stringify(body);
+                        this.log.error('Server did not response with a websocket host. Response was [%s]', response);
+                        reject('Server did not response with a websocket host.');
+                    } else {
+                        this.log.debug('WebSocket host received [%s]', result.body.domain);
+                        this.config['webSocketApi'] = result.body.domain;
+                        
+                        resolve(result.body.domain);
+                    }
+                }).catch(err => {
+                    this.log.error('An error was encountered while getting websocket host. Error was [%s]', err);
+                    reject('An error was encountered while getting websocket host.');
+                });
+        });
     }
 
 }

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -396,6 +396,6 @@ module.exports = class EwelinkApi {
                 this.log.error('An error was encountered while getting websocket host. Error was [%s]', err);
                 throw new Error('An error was encountered while getting websocket host.');
             });
-    };
+    }
 
 }

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -3,6 +3,13 @@ let crypto = require('crypto');
 const querystring = require('querystring');
 const { resolve } = require('path');
 
+/**
+ * Class exposing methods to interact with Ewelink through their HTTP API.
+ * 
+ * TODO:
+ * - Rate limiting
+ * - response caching (may be the same thing)
+ */
 module.exports = class EwelinkApi {
 
     /**
@@ -131,6 +138,7 @@ module.exports = class EwelinkApi {
                     }
                     throw new Error('API returned error response');
                 } else {
+                    this.log.debug('Returning device list: %o', result.body.devicelist);
                     return (result.body.devicelist);
                 }
 
@@ -139,6 +147,40 @@ module.exports = class EwelinkApi {
                 
                 throw new Error(err);
             });
+    }
+
+    /**
+     * Get the status of a device. 
+     * 
+     * This comes from the listDevices API, and just filters to return the
+     * details for a single device. 
+     * 
+     * @param {*} deviceId 
+     * @returns a promise. This will return the single device from the API call, 
+     *          or throw an Error if it cannot be found. 
+     */
+    async getDeviceStatus(deviceId) {
+
+        const devices = await this.listDevices();
+
+        let filteredDevices = devices.filter(device => (device.deviceid === deviceId));
+
+        if (filteredDevices.length === 1) {
+            this.log.debug('Got device: %s', filteredDevices[0]);
+            return filteredDevices[0];
+        } else if (filteredDevices.length > 1) {
+            // More than one device matches our Device ID. This should not happen.
+            this.log.error('ERROR: The response contained more than one device with Device ID [%s]. Filtered response: %o', 
+                deviceId, filteredDevices);
+                    
+            throw new Error('The response contained more than one device with Device ID ' + deviceId);
+            
+        } else {
+            /* Response did not contain the device ID, the device is no longer registered. */
+            this.log.error('Device [%s] did not exist in the response.', deviceId);
+            throw new Error('The response contained no devices with Device ID ' + deviceId);
+        }
+
     }
 
     /**

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -1,0 +1,47 @@
+let request = require('request-json');
+let crypto = require('crypto');
+
+module.exports = class EwelinkApi {
+
+    /**
+     * Create a new EwelinkApi
+     * @param {*} log the logger instance to use for log messages
+     * @param {*} config the plugin configuration
+     */
+    constructor(log, config) {
+        this.log = log;
+        this.config = config;
+
+    }
+
+    /**
+   * Helper method to set the common values all implementations or BaseApiRequest are
+   * expected to include before being sent with API requests. 
+   * @param obj the object to populate the fields in
+   * @returns the updated object. 
+   */
+   populateCommonApiRequestFields(obj) {
+
+    obj.version = '6';
+    obj.ts = '' + Math.floor(new Date().getTime() / 1000);
+    obj.nonce = this.nonce();
+    obj.appid = 'oeVkj2lYFGnJu5XUtWisfW4utiN4u9Mq';
+    obj.imei = this.config.imei;
+    obj.os = 'iOS';
+    obj.model = 'iPhone10,6';
+    obj.romVersion = '11.1.2';
+    obj.appVersion = '3.5.3';
+
+    return obj;
+  }
+
+  /**
+   * Generate a nonce for sending with API requests. 
+   * 
+   * @returns the base64 encoded nonce.
+   */
+  nonce() {
+    return crypto.randomBytes(16).toString('base64');
+  }
+
+}

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -127,6 +127,12 @@ module.exports = class EwelinkApi {
      */
     async listDevices() {
 
+        /* We can only make calls if we have an authentication token */
+        if (!this.authenticationToken) {
+            throw new Error('No authentication token found. ' +  
+                'This is likely caused by attempting to get devices before logging in');
+        }
+
         const url = 'https://' + this.config['apiHost'];
 
         this.log.debug('Requesting a list of devices from eWeLink HTTPS API at [%s]', url);
@@ -157,7 +163,7 @@ module.exports = class EwelinkApi {
                     }
                     throw new Error('API returned error response');
                 } else {
-                    this.log.debug('Returning device list: %o', result.body.devicelist);
+                    // this.log.debug('Returning device list: %o', result.body.devicelist);
                     return (result.body.devicelist);
                 }
 

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -11,6 +11,7 @@ module.exports = class EwelinkApi {
      * @param {*} config the plugin configuration
      */
     constructor(log, config) {
+
         this.log = log;
 
 
@@ -64,12 +65,12 @@ module.exports = class EwelinkApi {
 
         let args = {
             lang: 'en',
-            apiKey = this.apiKey,
-            getTags = '1'
+            apiKey: this.apiKey,
+            getTags: '1'
         };
 
         /* Add in the common values that are common accross all API requests */
-        args = populateCommonApiRequestFields(args);
+        args = this.populateCommonApiRequestFields(args);
 
         return querystring.stringify(args);
     }
@@ -110,123 +111,129 @@ module.exports = class EwelinkApi {
 
         this.log.debug('Requesting a list of devices from eWeLink HTTPS API at [%s]', url);
 
-        return new Promise((resolve, reject) => {
+        
+        let webClient = request.createClient(url);
+        webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
+        return await webClient.get('/api/user/device?' + this.getArgumentQueryString())
+            .then(result => {
 
-            let webClient = request.createClient(url);
-            webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
-            webClient.get('/api/user/device?' + this.getArguments())
-                .then(result => {
+                if (!result.body) {
 
-                    if (!result.body) {
+                    const message = 'An error was encountered while requesting a list of devices. No data in response.';
 
-                        const message = 'An error was encountered while requesting a list of devices. No data in response.';
-
-                        this.log.error(message);
-                        reject(message);
-                    } else if (body.error && body.error != 0) {
-                        let response = JSON.stringify(body);
-                        this.log.error('An error was encountered while requesting a list of devices. Response was [%s]', response);
-                        if (body.error === '401') {
-                            this.log.error('Verify that you have the correct authenticationToken specified in your configuration. The currently-configured token is [%s]', platform.authenticationToken);
-                        }
-                        reject('API returned error response');
-                    } else {
-                        resolve(body.devicelist);
+                    this.log.error(message);
+                    throw new Error(message);
+                } else if (result.body.error && result.body.error != 0) {
+                    let response = JSON.stringify(result.body);
+                    this.log.error('An error was encountered while requesting a list of devices. Response was [%s]', response);
+                    if (result.body.error === '401') {
+                        this.log.error('Verify that you have the correct authenticationToken specified in your configuration. The currently-configured token is [%s]', platform.authenticationToken);
                     }
+                    throw new Error('API returned error response');
+                } else {
+                    return (result.body.devicelist);
+                }
 
-                }).catch(err => {
-                    this.log.error('An error was encountered while requesting a list of devices. Error was [%s]', err);
-                    reject(err);
-                });
-        });
+            }).catch(err => {
+                this.log.error('An error was encountered while requesting a list of devices. Error was [%s]', err);
+                
+                throw new Error(err);
+            });
     }
 
     /**
      * Login to the Ewelink API
      * 
-     * @returns a promise. The resolve callback will be used when a valid authentication token it returned by the API. The reject callback will be used for all error conditions. 
+     * @returns a promise. The resolve callback will be used when a valid 
+     *          authentication token it returned by the API. The return type will be an 
+     *          object with two fields, authenticationToken and apiKey. 
+     *          The reject callback will be used for all error conditions. 
      */
     async login() {
 
+        /* Check the configuration is good */
+        if (!this.config.phoneNumber && !this.config.email || !this.config.password || !this.config.imei) {
+            const message = 'phoneNumber / email / password / imei not found in config, skipping login';
+            this.log.error(message);
+            throw new Error(message);
+        } else {
+            /* Configuration is good, try to make the API call */
 
-        return new Promise((resolve, reject) => {
-
-            /* Check the configuration is good */
-            if (!this.config.phoneNumber && !this.config.email || !this.config.password || !this.config.imei) {
-                const message = 'phoneNumber / email / password / imei not found in config, skipping login';
-                this.log.error(message);
-                reject(message);
-            } else {
-                /* Configuration is good, try to make the API call */
-
-                /* Setup the Object with the API request data */
-                let data = {};
-                if (this.config.phoneNumber) {
-                    data.phoneNumber = this.config.phoneNumber;
-                } else if (this.config.email) {
-                    data.email = this.config.email;
-                }
-                data.password = this.config.password;
-
-                /* Setup the fields which are common to all API calls */
-                data = this.populateCommonApiRequestFields(data);
-
-
-                const json = JSON.stringify(data);
-                this.log.debug('Sending login request with user credentials: %s', json);
-
-                let sign = this.getSignature(json);
-                this.log.debug('Login signature: %s', sign);
-
-                let webClient = request.createClient('https://' + this.config.apiHost);
-                webClient.headers['Authorization'] = 'Sign ' + sign;
-                webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
-                webClient.post('/api/user/login', data)
-                    .then(result => {
-
-                        // If we receive 301 error, switch to new region and try again
-                        if (result.body.error && result.body.error == 301 && result.body.region) {
-                            let idx = this.config.apiHost.indexOf('-');
-                            if (idx == -1) {
-                                this.log.error('Received new region [%s]. However we cannot construct the new API host url.', body.region);
-                                reject('Received new region, however we cannot construct the new API host url.');
-                            } else {
-                                let newApiHost = result.body.region + this.config.apiHost.substring(idx);
-                                if (this.config.apiHost != newApiHost) {
-                                    this.log('Received new region [%s], updating API host to [%s].', result.body.region, newApiHost);
-                                    this.config.apiHost = newApiHost;
-                                    this.login()
-                                        .then(result => resolve(result))
-                                        .catch(err => reject(err));
-                                }
-                            }
-                        } else if (!result.body.at) {
-                            let response = JSON.stringify(result.body);
-                            this.log.error('Server did not response with an authentication token. Response was [%s]', response);
-                            reject('Server did not response with an authentication token.')
-                        } else {
-                            /* Successful login and body looks as expected, return the authentication token (and set it locally) */
-                            this.log.debug('Authentication token received [%s]', result.body.at);
-                            this.authenticationToken = result.body.at;
-                            this.config.authenticationToken = result.body.at;
-
-                            resolve(result.body.at);
-                        }
-
-
-                    }).catch(err => {
-                        this.log.error('An error was encountered while logging in. Error was [%s]', err);
-                        reject('An error was encountered while logging in.');
-                    });
-
+            /* Setup the Object with the API request data */
+            let data = {};
+            if (this.config.phoneNumber) {
+                data.phoneNumber = this.config.phoneNumber;
+            } else if (this.config.email) {
+                data.email = this.config.email;
             }
+            data.password = this.config.password;
 
-        });
+            /* Setup the fields which are common to all API calls */
+            data = this.populateCommonApiRequestFields(data);
 
 
+            const json = JSON.stringify(data);
+            this.log.debug('Sending login request with user credentials: %s', json);
+
+            let sign = this.getSignature(json);
+            this.log.debug('Login signature: %s', sign);
+
+            let webClient = request.createClient('https://' + this.config.apiHost);
+            webClient.headers['Authorization'] = 'Sign ' + sign;
+            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+            await webClient.post('/api/user/login', data)
+                .then(result => {
+
+                    // If we receive 301 error, switch to new region and try again
+                    if (result.body.error && result.body.error == 301 && result.body.region) {
+                        let idx = this.config.apiHost.indexOf('-');
+                        if (idx == -1) {
+                            this.log.error('Received new region [%s]. However we cannot construct the new API host url.', body.region);
+                            throw new Error('Received new region, however we cannot construct the new API host url.');
+                        } else {
+                            let newApiHost = result.body.region + this.config.apiHost.substring(idx);
+                            if (this.config.apiHost != newApiHost) {
+                                this.log('Received new region [%s], updating API host to [%s].', result.body.region, newApiHost);
+                                this.config.apiHost = newApiHost;
+                                this.login()
+                                    .then(loginResult => {
+                                        return loginResult
+                                    }).catch(err => {
+                                        throw new Error(err)
+                                    });
+                            }
+                        }
+                    } else if (!result.body.at) {
+                        let response = JSON.stringify(result.body);
+                        this.log.error('Server did not response with an authentication token. Response was [%s]', response);
+                        throw new Error('Server did not response with an authentication token.')
+                    } else {
+                        /* Successful login and body looks as expected, return the authentication token (and set it locally) */
+                        this.log.debug('Authentication token received [%s]', result.body.at);
+                        this.log.debug('Login response body: %o', result.body);
+                        this.authenticationToken = result.body.at;
+                        this.config.authenticationToken = this.authenticationToken;
+                        this.apiKey = result.body.user.apikey;
+                        this.config.apiKey = this.apiKey;
+
+                        let returnObject = {
+                            authenticationToken: this.authenticationToken,
+                            apiKey: this.apiKey
+                        };
+
+                        this.log.debug('Login returning: %o', returnObject);
+
+                        return returnObject;
+                    }
 
 
-    };
+                }).catch(err => {
+                    this.log.error('An error was encountered while logging in. Error was [%s]', err);
+                    throw new Error('An error was encountered while logging in.');
+                });
+
+        }
+    }
 
     /**
      * Get the correct API server region for the supplied country code.
@@ -239,7 +246,7 @@ module.exports = class EwelinkApi {
 
         /* Set the arguments specific to this API call */
         var data = {
-            country_code = countryCode
+            country_code: countryCode
         };
         /* Set the arguments that apply to all API calls */
         data = this.populateCommonApiRequestFields(data);
@@ -249,33 +256,34 @@ module.exports = class EwelinkApi {
         this.log.debug('getRegion query: %s', query);
 
         /* Create a signature for the request */
-        const dataToSign = Object.keys(requestParams)
+        const dataToSign = Object.keys(data)
             .sort((a, b) => b.localeCompare(a))
-            .map(key => key + '=' + requestParams[key])
+            .map(key => key + '=' + data[key])
             .join('&');
 
         const signature = this.getSignature(dataToSign);
         this.log.debug('getRegion signature: %s', signature);
 
-        return new Promise((resolve, reject) => {
-            let webClient = request.createClient('https://api.coolkit.cc:8080');
-            webClient.headers['Authorization'] = 'Sign ' + sign;
-            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
-            webClient.get('/api/user/region?' + query)
-                .then(result => {
-                    if (!result.body.region) {
-                        let response = JSON.stringify(body);
-                        this.log.error('Server did not response with a region. Response was [%s]', response);
-                        reject('Server did not response with a region.');
-                    } else {
-                        resolve(result.body.region);
-                    }
+        
+        let webClient = request.createClient('https://api.coolkit.cc:8080');
+        webClient.headers['Authorization'] = 'Sign ' + signature;
+        webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
 
-                }).catch(err => {
-                    this.log.error('An error was encountered while getting region. Error was [%s]', err);
-                    reject('An error was encountered while getting region.');
-                });
-        });
+        return await webClient.get('/api/user/region?' + query)
+            .then(result => {
+                if (!result.body.region) {
+                    let response = JSON.stringify(result.body);
+                    this.log.error('Server did not response with a region. Response was [%s]', response);
+                    throw new Error('Server did not response with a region.');
+                } else {
+                    this.log.debug('Got region: %s', result.body.region);
+                    return result.body.region;
+                }
+
+            }).catch(err => {
+                this.log.error('An error was encountered while getting region. Error was [%s]', err);
+                throw new Error('An error was encountered while getting region.');
+            });
 
     }
 
@@ -295,30 +303,28 @@ module.exports = class EwelinkApi {
         /* Set the arguments that apply to all API calls */
         data = this.populateCommonApiRequestFields(data);
         
-        return new Promise((resolve, reject) => {
-            let webClient = request.createClient('https://' + this.config.apiHost.replace('-api', '-disp'));
-            webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
-            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
-            webClient.post('/dispatch/app', data)
-                .then(result => {
+        
+        let webClient = request.createClient('https://' + this.config.apiHost.replace('-api', '-disp'));
+        webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
+        webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+        webClient.post('/dispatch/app', data)
+            .then(result => {
 
-                    if (!result.body.domain) {
-                        /* Response body did not contain the field we expected */
-                        let response = JSON.stringify(body);
-                        this.log.error('Server did not response with a websocket host. Response was [%s]', response);
-                        reject('Server did not response with a websocket host.');
-                    } else {
-                        this.log.debug('WebSocket host received [%s]', result.body.domain);
-                        this.config['webSocketApi'] = result.body.domain;
-                        
-                        resolve(result.body.domain);
-                    }
-                }).catch(err => {
-                    this.log.error('An error was encountered while getting websocket host. Error was [%s]', err);
-                    reject('An error was encountered while getting websocket host.');
-                });
-            
-        });
+                if (!result.body.domain) {
+                    /* Response body did not contain the field we expected */
+                    let response = JSON.stringify(body);
+                    this.log.error('Server did not response with a websocket host. Response was [%s]', response);
+                    throw new Error('Server did not response with a websocket host.');
+                } else {
+                    this.log.debug('WebSocket host received [%s]', result.body.domain);
+                    this.config['webSocketApi'] = result.body.domain;
+                    
+                    return result.body.domain;
+                }
+            }).catch(err => {
+                this.log.error('An error was encountered while getting websocket host. Error was [%s]', err);
+                throw new Error('An error was encountered while getting websocket host.');
+            });
     };
 
 }

--- a/lib/ewelinkApi.js
+++ b/lib/ewelinkApi.js
@@ -1,5 +1,7 @@
 let request = require('request-json');
 let crypto = require('crypto');
+const querystring = require('querystring');
+const { resolve } = require('path');
 
 module.exports = class EwelinkApi {
 
@@ -10,38 +12,313 @@ module.exports = class EwelinkApi {
      */
     constructor(log, config) {
         this.log = log;
+
+
+        /* Validate & initialise configuration */
+        if (!config ||
+            (!config['authenticationToken'] &&
+                ((!config['phoneNumber'] && !config['email']) ||
+                    !config['password'] ||
+                    !config['imei']))) {
+
+            log.warn('Initialization skipped. Missing configuration data.');
+            return;
+        }
+
+        if (!config['apiHost']) {
+            config['apiHost'] = 'eu-api.coolkit.cc:8080';
+        }
+        if (!config['webSocketApi']) {
+            config['webSocketApi'] = 'us-pconnect3.coolkit.cc';
+        }
+
         this.config = config;
 
     }
 
     /**
-   * Helper method to set the common values all implementations or BaseApiRequest are
-   * expected to include before being sent with API requests. 
-   * @param obj the object to populate the fields in
-   * @returns the updated object. 
-   */
-   populateCommonApiRequestFields(obj) {
+     * Helper method to set the common values all implementations or BaseApiRequest are
+     * expected to include before being sent with API requests. 
+     * @param obj the object to populate the fields in
+     * @returns the updated object. 
+     */
+    populateCommonApiRequestFields(obj) {
 
-    obj.version = '6';
-    obj.ts = '' + Math.floor(new Date().getTime() / 1000);
-    obj.nonce = this.nonce();
-    obj.appid = 'oeVkj2lYFGnJu5XUtWisfW4utiN4u9Mq';
-    obj.imei = this.config.imei;
-    obj.os = 'iOS';
-    obj.model = 'iPhone10,6';
-    obj.romVersion = '11.1.2';
-    obj.appVersion = '3.5.3';
+        obj.version = '6';
+        obj.ts = '' + Math.floor(new Date().getTime() / 1000);
+        obj.nonce = this.nonce();
+        obj.appid = 'oeVkj2lYFGnJu5XUtWisfW4utiN4u9Mq';
+        obj.imei = this.config.imei;
+        obj.os = 'iOS';
+        obj.model = 'iPhone10,6';
+        obj.romVersion = '11.1.2';
+        obj.appVersion = '3.5.3';
 
-    return obj;
-  }
+        return obj;
+    }
 
-  /**
-   * Generate a nonce for sending with API requests. 
-   * 
-   * @returns the base64 encoded nonce.
-   */
-  nonce() {
-    return crypto.randomBytes(16).toString('base64');
-  }
+    /**
+     * Create the arguments as a query string for a GET request
+     */
+    getArgumentQueryString() {
+
+        let args = {
+            lang: 'en',
+            apiKey = this.apiKey,
+            getTags = '1'
+        };
+
+        /* Add in the common values that are common accross all API requests */
+        args = populateCommonApiRequestFields(args);
+
+        return querystring.stringify(args);
+    }
+
+    /**
+     * Generate a nonce for sending with API requests. 
+     * 
+     * @returns the base64 encoded nonce.
+     */
+    nonce() {
+        return crypto.randomBytes(16).toString('base64');
+    }
+
+    /**
+     * Generate an HMAC signature for the supplied data string. 
+     * @param string the input string to get a signature for. 
+     */
+    getSignature(string) {
+        //let appSecret = "248,208,180,108,132,92,172,184,256,152,256,144,48,172,220,56,100,124,144,160,148,88,28,100,120,152,244,244,120,236,164,204";
+        //let f = "ab!@#$ijklmcdefghBCWXYZ01234DEFGHnopqrstuvwxyzAIJKLMNOPQRSTUV56789%^&*()";
+        //let decrypt = function(r){var n="";return r.split(',').forEach(function(r){var t=parseInt(r)>>2,e=f.charAt(t);n+=e}),n.trim()};
+        let decryptedAppSecret = '6Nz4n0xA8s8qdxQf2GqurZj2Fs55FUvM'; //decrypt(appSecret);
+        return crypto.createHmac('sha256', decryptedAppSecret).update(string).digest('base64');
+    }
+
+    /**
+     * Call the Ewelink API to list the devices.
+     * 
+     * This handles some of the error cases the plugin previously handled where 
+     * the response wasn't an error, but some fields were missing. 
+     * 
+     * @returns a promise for the get request. The resolve result will be the device list 
+     *          from the API. Any other error case will use the rejection call. 
+     */
+    async listDevices() {
+
+        const url = 'https://' + this.config['apiHost'];
+
+        this.log.debug('Requesting a list of devices from eWeLink HTTPS API at [%s]', url);
+
+        return new Promise((resolve, reject) => {
+
+            let webClient = request.createClient(url);
+            webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
+            webClient.get('/api/user/device?' + this.getArguments())
+                .then(result => {
+
+                    if (!result.body) {
+
+                        const message = 'An error was encountered while requesting a list of devices. No data in response.';
+
+                        this.log.error(message);
+                        reject(message);
+                    } else if (body.error && body.error != 0) {
+                        let response = JSON.stringify(body);
+                        this.log.error('An error was encountered while requesting a list of devices. Response was [%s]', response);
+                        if (body.error === '401') {
+                            this.log.error('Verify that you have the correct authenticationToken specified in your configuration. The currently-configured token is [%s]', platform.authenticationToken);
+                        }
+                        reject('API returned error response');
+                    } else {
+                        resolve(body.devicelist);
+                    }
+
+                }).catch(err => {
+                    this.log.error('An error was encountered while requesting a list of devices. Error was [%s]', err);
+                    reject(err);
+                });
+        });
+    }
+
+    /**
+     * Login to the Ewelink API
+     * 
+     * @returns a promise. The resolve callback will be used when a valid authentication token it returned by the API. The reject callback will be used for all error conditions. 
+     */
+    async login() {
+
+
+        return new Promise((resolve, reject) => {
+
+            /* Check the configuration is good */
+            if (!this.config.phoneNumber && !this.config.email || !this.config.password || !this.config.imei) {
+                const message = 'phoneNumber / email / password / imei not found in config, skipping login';
+                this.log.error(message);
+                reject(message);
+            } else {
+                /* Configuration is good, try to make the API call */
+
+                /* Setup the Object with the API request data */
+                let data = {};
+                if (this.config.phoneNumber) {
+                    data.phoneNumber = this.config.phoneNumber;
+                } else if (this.config.email) {
+                    data.email = this.config.email;
+                }
+                data.password = this.config.password;
+
+                /* Setup the fields which are common to all API calls */
+                data = this.populateCommonApiRequestFields(data);
+
+
+                const json = JSON.stringify(data);
+                this.log.debug('Sending login request with user credentials: %s', json);
+
+                let sign = this.getSignature(json);
+                this.log.debug('Login signature: %s', sign);
+
+                let webClient = request.createClient('https://' + this.config.apiHost);
+                webClient.headers['Authorization'] = 'Sign ' + sign;
+                webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+                webClient.post('/api/user/login', data)
+                    .then(result => {
+
+                        // If we receive 301 error, switch to new region and try again
+                        if (result.body.error && result.body.error == 301 && result.body.region) {
+                            let idx = this.config.apiHost.indexOf('-');
+                            if (idx == -1) {
+                                this.log.error('Received new region [%s]. However we cannot construct the new API host url.', body.region);
+                                reject('Received new region, however we cannot construct the new API host url.');
+                            } else {
+                                let newApiHost = result.body.region + this.config.apiHost.substring(idx);
+                                if (this.config.apiHost != newApiHost) {
+                                    this.log('Received new region [%s], updating API host to [%s].', result.body.region, newApiHost);
+                                    this.config.apiHost = newApiHost;
+                                    this.login()
+                                        .then(result => resolve(result))
+                                        .catch(err => reject(err));
+                                }
+                            }
+                        } else if (!result.body.at) {
+                            let response = JSON.stringify(result.body);
+                            this.log.error('Server did not response with an authentication token. Response was [%s]', response);
+                            reject('Server did not response with an authentication token.')
+                        } else {
+                            /* Successful login and body looks as expected, return the authentication token (and set it locally) */
+                            this.log.debug('Authentication token received [%s]', result.body.at);
+                            this.authenticationToken = result.body.at;
+                            this.config.authenticationToken = result.body.at;
+
+                            resolve(result.body.at);
+                        }
+
+
+                    }).catch(err => {
+                        this.log.error('An error was encountered while logging in. Error was [%s]', err);
+                        reject('An error was encountered while logging in.');
+                    });
+
+            }
+
+        });
+
+
+
+
+    };
+
+    /**
+     * Get the correct API server region for the supplied country code.
+     * 
+     * @param {string} countryCode  the country code to get the API region for. 
+     * @returns a promise. The resolve callback will be called with the region code. 
+     *          Any error condition will call the reject callback with an error message. 
+     */
+    async getRegion(countryCode) {
+
+        /* Set the arguments specific to this API call */
+        var data = {
+            country_code = countryCode
+        };
+        /* Set the arguments that apply to all API calls */
+        data = this.populateCommonApiRequestFields(data);
+
+
+        let query = querystring.stringify(data);
+        this.log.debug('getRegion query: %s', query);
+
+        /* Create a signature for the request */
+        const dataToSign = Object.keys(requestParams)
+            .sort((a, b) => b.localeCompare(a))
+            .map(key => key + '=' + requestParams[key])
+            .join('&');
+
+        const signature = this.getSignature(dataToSign);
+        this.log.debug('getRegion signature: %s', signature);
+
+        return new Promise((resolve, reject) => {
+            let webClient = request.createClient('https://api.coolkit.cc:8080');
+            webClient.headers['Authorization'] = 'Sign ' + sign;
+            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+            webClient.get('/api/user/region?' + query)
+                .then(result => {
+                    if (!result.body.region) {
+                        let response = JSON.stringify(body);
+                        this.log.error('Server did not response with a region. Response was [%s]', response);
+                        reject('Server did not response with a region.');
+                    } else {
+                        resolve(result.body.region);
+                    }
+
+                }).catch(err => {
+                    this.log.error('An error was encountered while getting region. Error was [%s]', err);
+                    reject('An error was encountered while getting region.');
+                });
+        });
+
+    }
+
+    /**
+     * Get the correct websocket host for the current API session.
+     * 
+     * @returns a promise. The resolve callback will be called with the websocket host. 
+     *          Any error condition will call the reject callback with an error message. 
+     */
+    async getWebSocketHost() {
+
+        /* Set the request data that is specific to this API invocation */
+        let data = {
+            accept: 'mqtt,ws'
+        };
+
+        /* Set the arguments that apply to all API calls */
+        data = this.populateCommonApiRequestFields(data);
+        
+        return new Promise((resolve, reject) => {
+            let webClient = request.createClient('https://' + this.config.apiHost.replace('-api', '-disp'));
+            webClient.headers['Authorization'] = 'Bearer ' + this.authenticationToken;
+            webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+            webClient.post('/dispatch/app', data)
+                .then(result => {
+
+                    if (!result.body.domain) {
+                        /* Response body did not contain the field we expected */
+                        let response = JSON.stringify(body);
+                        this.log.error('Server did not response with a websocket host. Response was [%s]', response);
+                        reject('Server did not response with a websocket host.');
+                    } else {
+                        this.log.debug('WebSocket host received [%s]', result.body.domain);
+                        this.config['webSocketApi'] = result.body.domain;
+                        
+                        resolve(result.body.domain);
+                    }
+                }).catch(err => {
+                    this.log.error('An error was encountered while getting websocket host. Error was [%s]', err);
+                    reject('An error was encountered while getting websocket host.');
+                });
+            
+        });
+    };
 
 }

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -436,7 +436,7 @@ module.exports = class LanClient {
         };
 
 
-        this.log.debug('Pre-encryption payload: %s', JSON.stringify(payload));
+        this.log.debug('Pre-encryption payload: %o', payload);
 
         if (this.localDevice.data.encrypt) {
             /* if we have an API key, need to encrypt the data */
@@ -460,6 +460,40 @@ module.exports = class LanClient {
         /* Return the promise for the request */
         this.log.debug('Sending call to path: %s', path);
         return webClient.post(path, payload);
+    }
+
+    /**
+     * Set the new status params for a device. 
+     * @param {*} accessory the accessory to set the status for
+     * @param {*} statusParams the new device status params
+     * 
+     * @returns a promise returning the result of the update request. 
+     *          If this device does not support a lan client, an "Unsupported" 
+     *          error will be returned. 
+     */
+    async updateDeviceStatus(accessory, statusParams) {
+
+
+        let path;
+        if (statusParams.switch) {
+            /* Single switch device */
+            path = '/zeroconf/switch';
+        } else if (statusParams.switches) {
+            /* Multiple Switch Device */
+            path = '/zeroconf/switches';
+        }
+
+
+        if (!path) {
+            throw new Error("Unsupported");
+        } else {
+            /* Do a lan API call */
+            return await doApiCall(accessory.context.deviceId, path, statusParams);
+        }
+        
+
+        
+
     }
 
     /**

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -4,6 +4,16 @@ let crypto = require('crypto');
 const mdns = require('multicast-dns')()
 
 
+/**
+ * Class for interacting with devices using the LAN API and 
+ * multicast DNS. 
+ * 
+ * TODO: 
+ * - Change so "get" requests use promises, return the decrypted device state.
+ *   This means it can be used the same way as the WebSocket and HTTP clients. 
+ * - Also needs a way to keep a handle on if a device supports LAN mode
+ *   This is the current TODO
+ */
 module.exports = class LanClient {
 
 
@@ -15,12 +25,14 @@ module.exports = class LanClient {
      */
     constructor(device, log) {
 
-        log.debug('Creating lan client for device %s', device.deviceid);
-
+        
         this.device = device;
         this.log = log;
-
-        this.deviceName = 'eWeLink_' + device.deviceid + '._ewelink._tcp.local';
+        
+        if (device) {
+            log.debug('Creating lan client for device %s', device.deviceid);
+            this.deviceName = 'eWeLink_' + device.deviceid + '._ewelink._tcp.local';
+        }
 
     }
 
@@ -145,6 +157,97 @@ module.exports = class LanClient {
         this.sendDnsQuery();
 
         return this.localDevice;
+    }
+
+    /**
+     * Get the status of a device. 
+     * 
+     * This comes from a combination of a few DNS responses.
+     * 
+     * @param {*} deviceId 
+     * @param {*} deviceKey
+     * @returns a promise. This will return the single device from the API call, 
+     *          or throw an Error if it cannot be found. 
+     */
+    getDeviceStatus(deviceId, deviceKey) {
+
+        return new Promise((resolve, reject) => {
+            let deviceName = 'eWeLink_' + deviceId + '._ewelink._tcp.local';
+            this.log.debug('TEST LOG: %s', deviceName);
+
+            // const mdnsClient = multicastdns();
+            const mdnsClient = require('multicast-dns')();
+            let status = {};
+
+            mdnsClient.on('response', response => {
+                if (response.answers) {
+                    response.answers
+                        .filter(value => value.name === deviceName)
+                        .forEach(value => {
+                            this.log.debug('DNS Response: %o', response);
+        
+                            if (value.type === 'TXT') {
+                                const processedDeviceResponse = Object.assign({}, value);
+
+                                let dataObject = {};
+
+                                value.data.forEach(dataValue => {
+                                    // this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
+
+                                    let bufferString = dataValue.toString('utf-8');
+                                    let key = bufferString.substr(0, bufferString.indexOf('='));
+
+                                    dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
+                                });
+
+                                // this.log.debug('DNS txt record for device %s is: %o',
+                                //     this.device.deviceid, dataObject);
+                                processedDeviceResponse.data = dataObject;
+
+
+                                /* Turn this TXT record into something usable for the state */
+                                const stateData = this.extractDataFromDnsService(dataObject, deviceKey);
+                                // this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
+                                status.params = stateData;
+
+                                status.txt = processedDeviceResponse;
+                            } else if (value.type === 'SRV') {
+                                status.srv = value;
+                            } else {
+                                this.log.debug('Unhandled device DNS answer: %o', value);
+                            }
+
+                            if (status.srv && status.txt) {
+                                resolve(status);
+                                mdnsClient.destroy();
+                            }
+                        });
+                }
+            });
+
+            mdnsClient.query({
+                questions: [
+                    {
+                        name: '_ewelink._tcp.local',
+                        type: 'TXT'
+                    },
+                    {
+                        name: 'eWeLink_' + deviceId + '.local',
+                        type: 'A'
+                    },
+                    {
+                        name: 'eWeLink_' + deviceId + '.local',
+                        type: 'SRV'
+                    }
+                ]
+            }, () => this.log.debug('DNS QUERY SENT'));
+
+            /* We don't want to wait for long, so reject the promise after a second */
+            setTimeout(() => {
+                mdnsClient.destroy();
+                reject('DNS request timed out for device ' + deviceId);
+            }, 1000);
+        });
     }
 
     /**

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -19,54 +19,74 @@ module.exports = class LanClient {
 
 
     /**
-     * 
-     * @param {*} device 
+     * Create a new LanClient. 
      * @param {*} log the logger instance to use for log messages
      */
-    constructor(device, log) {
+    constructor(log) {
 
-        
-        this.device = device;
         this.log = log;
-        
-        if (device) {
-            log.debug('Creating lan client for device %s', device.deviceid);
-            this.deviceName = 'eWeLink_' + device.deviceid + '._ewelink._tcp.local';
-        }
 
+        /**
+         * Map of deviceId to their last known DNS state. 
+         * 
+         * TODO: interval clearing this out after a TTL?
+         */
+        this.deviceMap = new Map();
+
+        /**
+         * Map of deviceId to their corresponding deviceKey.
+         * This is required to allow decryption of DNS data to occur. 
+         */
+        this.deviceKeyMap = new Map();
+
+    }
+
+    /**
+     * Add a device key for a device to allow decryption to occur. 
+     * @param {string} deviceId the id of the device. 
+     * @param {string} deviceKey the key for the device. 
+     */
+    addDeviceKey(deviceId, deviceKey) {
+        this.log.debug('Adding device key %s for device %s', deviceKey, deviceId);
+        this.deviceKeyMap.set(deviceId, deviceKey);
     }
 
     /**
      * Register internal listeners and make an initial query to attempt local discovery of the device. 
      */
     start() {
-        this.log.debug('Starting lan client for device %s', this.device.deviceid);
+        this.log.debug('Starting lan client');
 
         mdns.on('response', response => this.processDnsResponse(response));
 
-        /* Send the initial query */
-        this.sendDnsQuery();
+        /* Send the DNS queries every 5 minutes (300 s) */
+        setInterval(() => this.sendDnsQuery(), (300 * 1000));
     }
 
     /**
      * Sends a DNS query to discover devices
      */
-    async sendDnsQuery() {
+    sendDnsQuery() {
+
+        let questions = [
+            {
+                name: '_ewelink._tcp.local',
+                type: 'TXT'
+            }
+        ];
+
+        //TODO: Iterate through known devices and add them to the queries
+        //{
+            //     name: 'eWeLink_' + this.device.deviceid + '.local',
+            //     type: 'A'
+            // },
+            // {
+            //     name: 'eWeLink_' + this.device.deviceid + '.local',
+            //     type: 'SRV'
+            // }
+
         mdns.query({
-            questions: [
-                {
-                    name: '_ewelink._tcp.local',
-                    type: 'TXT'
-                },
-                {
-                    name: 'eWeLink_' + this.device.deviceid + '.local',
-                    type: 'A'
-                },
-                {
-                    name: 'eWeLink_' + this.device.deviceid + '.local',
-                    type: 'SRV'
-                }
-            ]
+            questions: questions
         });
     }
 
@@ -92,10 +112,24 @@ module.exports = class LanClient {
         /* find the item for the device */
         if (response.answers) {
             response.answers
-                .filter(value => value.name === this.deviceName)
+                .filter(value => value.name.startsWith('eWeLink_'))
+                // .filter(value => value.name === this.deviceName)
                 .forEach(value => {
                     // this.log.debug('DNS Response: %o', response);
 
+                    /* Get the deviceId from the device name */
+                    let deviceId = value.name.substr(8, 10);
+                    this.log.debug('parsedDeviceId for name %s is %s. Record type %s', value.name, deviceId, value.type);
+
+                    let status = this.deviceMap.get(deviceId);
+                    if (!status) {
+                        /* Need to create the object to put in the map */
+                        status = {};
+                    }
+
+                    /* TODO: Solve duplication with getDeviceStatus, possibly just look for SRV records
+                     *        here, and use that to trigger a call to getDeviceStatus?
+                     */ 
                     if (value.type === 'TXT') {
                         /* TXT records contain the state for the device */
 
@@ -121,26 +155,31 @@ module.exports = class LanClient {
 
 
                         /* Turn this TXT record into something usable for the state */
-                        const stateData = this.extractDataFromDnsService(dataObject, this.device.devicekey);
+                        const stateData = this.extractDataFromDnsService(dataObject, 
+                            this.deviceKeyMap.get(dataObject.id));
                         // this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
-                        processedDeviceResponse.data.state = stateData;
 
-                        this.localDevice = processedDeviceResponse;
+                        status.params = stateData;
+                        status.txt = processedDeviceResponse;
 
-                        this.log.debug('LocalDevice state for %s is: %o', this.device.deviceid, this.localDevice);
+                        this.log.debug('LocalDevice state for %s is: %o', deviceId, status.params);
                     } else if (value.type === 'SRV') {
                         /* A record contains the host details we need to invoke an API */
                         this.log.debug('DNS SRV answer: %o', value);
 
-                        this.localDeviceHost = {
+                        status.host = {
                             host: value.data.target,
                             port: value.data.port
                         };
+                        
+                        status.srv = value;
 
-                        this.log.debug('LocalDevice host for %s is: %o', this.device.deviceid, this.localDeviceHost);
+                        this.log.debug('LocalDevice host for %s is: %o', deviceId, status.host);
                     } else {
                         this.log.debug('Unhandled device DNS answer: %o', value);
                     }
+
+                    this.deviceMap.set(deviceId, status);
                 });
         }
 
@@ -206,13 +245,22 @@ module.exports = class LanClient {
 
 
                                 /* Turn this TXT record into something usable for the state */
-                                const stateData = this.extractDataFromDnsService(dataObject, deviceKey);
+                                const stateData = this.extractDataFromDnsService(dataObject, 
+                                    this.deviceKeyMap.get(dataObject.id));
                                 // this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
                                 status.params = stateData;
 
                                 status.txt = processedDeviceResponse;
                             } else if (value.type === 'SRV') {
+                                /* Store the whole SRV record */
                                 status.srv = value;
+
+                                /* Store a value with the parsed out information we need to connect */
+                                status.host = {
+                                    host: value.data.target,
+                                    port: value.data.port
+                                };
+
                             } else {
                                 this.log.debug('Unhandled device DNS answer: %o', value);
                             }
@@ -353,7 +401,7 @@ module.exports = class LanClient {
 
                 data = this.decrypt(data1, deviceKey, iv);
             } else {
-                this.log.error('Missing api_key for encrypted device %s', service.name);
+                this.log.error('Missing api_key for encrypted device %s', service.id);
             }
 
         } else {
@@ -372,16 +420,17 @@ module.exports = class LanClient {
     * the supplied data object with the result of the payload information. 
     * This will always make http requests. 
     *  
+    * @param {string} deviceId the id of the device. 
     * @param path the path to send the request to
     * @param data the data object containing the state to send to the device. The surrounding 
     *             payload fields are all handled by this method.
     */
-    async doApiCall(path, data) {
+    async doApiCall(deviceId, path, data) {
 
         const payload = {
             sequence: Date.now().toString(),
             selfApikey: '123',
-            deviceid: this.device.deviceid,
+            deviceid: deviceId,
             data: JSON.stringify(data),
             encrypt: false,
         };
@@ -393,7 +442,7 @@ module.exports = class LanClient {
             /* if we have an API key, need to encrypt the data */
             payload.encrypt = true;
 
-            const encryptionResult = this.encrypt(payload.data, this.device.devicekey);
+            const encryptionResult = this.encrypt(payload.data, this.deviceKeyMap.get(deviceId));
             payload.data = encryptionResult.data.toString('base64');
             payload.iv = encryptionResult.iv.toString('base64');
         }
@@ -411,24 +460,6 @@ module.exports = class LanClient {
         /* Return the promise for the request */
         this.log.debug('Sending call to path: %s', path);
         return webClient.post(path, payload);
-    }
-
-    /**
-     * Get the switch status of the current local device. 
-     * 
-     * @returns boolean of the switch status, or undefined if the device is not of the plug type
-     */
-    getSwitchStatus() {
-
-        this.log.debug('lanClient getSwitchStatus');
-
-        let result = undefined;
-        if (this.localDevice && this.localDevice.data.type === 'plug') {
-            result = this.localDevice.data.state.switch === 'on';
-        }
-
-        this.log.debug('lanClient getSwitchStatus result: %s', result);
-        return result;
     }
 
     /**
@@ -466,24 +497,4 @@ module.exports = class LanClient {
             })
     
     }
-
-    /**
-     * Get the power state for a single outlet in a strip
-     * @param {int} outlet the outlet index to get the state for. This is zero indexed. 
-     * 
-     * @returns boolean of the switch status, or undefined if the device is not of the strip type
-     */
-    getStripOutletStatus(outlet) {
-
-        this.log.debug('lanClient getStripOutletStatus %s', outlet);
-
-        let result = undefined;
-        if (this.localDevice && this.localDevice.data.type === 'strip') {
-            result = this.localDevice.data.state.switches[outlet].switch === 'on';
-        }
-
-        this.log.debug('lanClient getStripOutletStatus result: %s', result);
-        return result;
-    }
-
 }

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -1,0 +1,246 @@
+let request = require('request-json');
+let crypto = require('crypto');
+
+const mdns = require('multicast-dns')()
+
+
+module.exports = class LanClient {
+
+
+
+    /**
+     * 
+     * @param {*} device 
+     * @param {*} log the logger instance to use for log messages
+     */
+    constructor(device, log) {
+
+        this.device = device;
+        this.log = log;
+
+        this.deviceName = 'eWeLink_' + device.deviceid + '._ewelink._tcp.local';
+
+    }
+
+    start() {
+        mdns.on('response', response => this.processDnsResponse(response));
+
+        /* Send the initial query */
+        mdns.query({
+            questions: [
+                {
+                    name: '_ewelink._tcp.local',
+                    // type: 'PTR'
+                    // name: 'MacBook.local',
+                    type: 'TXT'
+                }
+            ]
+        });
+    }
+
+
+    processDnsResponse(response) {
+
+        /* find the item for the device */
+        if (response.answers) {
+            response.answers
+                .filter(value => value.name === this.deviceName && value.type === 'TXT')
+                .forEach(value => {
+                    this.log.debug('got a matching response for device %s: %o',
+                        this.device.deviceid, value)
+
+                    let dataObject = {};
+
+                    value.data.forEach(dataValue => {
+                        this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
+
+                        let bufferString = dataValue.toString('utf-8');
+                        let key = bufferString.substr(0, bufferString.indexOf('='));
+
+                        dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
+                    });
+
+                    this.log.debug('DNS txt record for device %s is: %o',
+                        this.device.deviceid, dataObject);
+
+                    
+                    /* Turn this TXT record into something usable for the state */
+                    const stateData = this.extractDataFromDnsService(dataObject, this.device.devicekey);
+                    this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
+                });
+
+        }
+    }
+
+
+    /**
+     * Decrypt the supplied data. 
+     * @param encryptedData the data to decrypt
+     * @param apiKey the API key for the device the encrypted data is for
+     * @param iv the initialisation vector associated with the encrypted message. 
+     * @returns string containing the decrypted data
+     */
+    decrypt(encryptedData, apiKey, iv) {
+        const cryptkey = crypto.createHash('md5')
+            .update(Buffer.from(apiKey, 'utf8'))
+            .digest();
+
+        const ivBuffer = Buffer.from(iv, 'base64');
+
+        const cipherText = Buffer.from(encryptedData, 'base64');
+
+
+        const decipher = crypto.createDecipheriv('aes-128-cbc', cryptkey, ivBuffer);
+
+        const plainText = Buffer.concat([
+            decipher.update(cipherText),
+            decipher.final(),
+        ]);
+
+        return plainText.toString('utf8');
+    }
+
+    /**
+    * Encrypt the supplied data. 
+    * @param plainText the data to encrypt
+    * @param apiKey the API key for the device the encrypted data is for
+    * @returns object containing the encrypted "data" and "iv" used for the encryption
+    */
+    encrypt(plainText, apiKey) {
+
+        const cryptkey = crypto.createHash('md5')
+            .update(Buffer.from(apiKey, 'utf8'))
+            .digest();
+
+        const iv = crypto.randomBytes(16);
+
+        const encipher = crypto.createCipheriv('aes-128-cbc', cryptkey, iv);
+
+        const cipherText = Buffer.concat([
+            encipher.update(plainText),
+            encipher.final(),
+        ]);
+
+        return {
+            data: cipherText,
+            iv: iv,
+        };
+
+    };
+
+    /**
+     * Extract the state data object from the MDNS service.
+     *
+     * @param service the service TXT record data from the mdns query
+     * @param deviceKey optional parameter. If this service is marked as encrypted then this 
+     *                  is required for part of the decryption, this is the decryption key.
+     * @returns object containing the data
+     */
+    extractDataFromDnsService(
+        service, deviceKey) {
+
+        /* DNS TXT records has limitation on field lengths, as a result the 
+         * data may be split into up to 4 fields. 
+         * Need to join these up. */
+
+        let data1 = service['data1'];
+        if (service['data2']) {
+
+            const data2 = service['data2'];
+            data1 += data2;
+
+            if (service['data3']) {
+
+                const data3 = service['data3'];
+                data1 += data3;
+
+                if (service['data4']) {
+
+                    const data4 = service['data4'];
+                    data1 += data4;
+
+                }
+            }
+        }
+
+        /* Convert the string into a usable object. 
+         * Depending on the device setup, this may need to be decrypted first */
+        let data;
+        if (service.encrypt) {
+            /* If this is marked as encrypted, we need an API key to decrypt. 
+            */
+            if (deviceKey !== undefined) {
+                /* Should be able to decrypt this data.
+                 * Requires to get the IV from another field */
+                const iv = service['iv'];
+
+                data = this.decrypt(data1, deviceKey, iv);
+            } else {
+                this.log.error('Missing api_key for encrypted device %s', service.name);
+            }
+
+        } else {
+            data = data1;
+        }
+
+        this.log.debug('Data: %o', data);
+
+
+        /* Convert to a JSON object */
+        return (data ? JSON.parse(data) : undefined);
+    };
+
+    /**
+    * Method to perform an API call to the device. This handles aspects of wrapping
+    * the supplied data object with the result of the payload information. 
+    * This will always make http requests. 
+    * @param log the logger instance to use for log messages
+    * @param host the host to send the request to
+    * @param port the port to send the request to. 
+    * @param path the path to send the request to
+    * @param deviceId the device identifier
+    * @param data the data object containing the state to send to the device. The surrounding 
+    *             payload fields are all handled by this method.
+    * @param apiKey the device API key. This optional parameter should only be supplied when
+    *               performing an operation against a device which is not in DIY mode and so
+    *               requires encrypted payloads to be sent. 
+    */
+    async doApiCall(log, host, port, path, deviceId, data, apiKey) {
+
+        const payload = {
+            sequence: Date.now().toString(),
+            selfApikey: '123',
+            deviceid: deviceId,
+            data: JSON.stringify(data),
+            encrypt: false,
+        };
+
+
+        log.debug('Pre-encryption payload: %s', JSON.stringify(payload));
+
+        if (apiKey) {
+            /* if we have an API key, need to encrypt the data */
+            payload.encrypt = true;
+
+            const encryptionResult = encrypt(payload.data, apiKey);
+            payload.data = encryptionResult.data.toString('base64');
+            payload.iv = encryptionResult.iv.toString('base64');
+        }
+
+        let connectionHost = 'http://' + host;
+        if (port) {
+            connectionHost += ':' + port;
+        }
+
+        let webClient = request.createClient(connectionHost);
+        webClient.headers['Accept'] = 'application/json';
+        webClient.headers['Content-Type'] = 'application/json;charset=UTF-8';
+        webClient.headers['Accept-Language'] = 'en-gb';
+
+        /* Return the promise for the request */
+        return webClient.post(path, payload);
+    }
+
+
+
+}

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -15,6 +15,8 @@ module.exports = class LanClient {
      */
     constructor(device, log) {
 
+        log.debug('Creating lan client for device %s', device.deviceid);
+
         this.device = device;
         this.log = log;
 
@@ -22,56 +24,128 @@ module.exports = class LanClient {
 
     }
 
+    /**
+     * Register internal listeners and make an initial query to attempt local discovery of the device. 
+     */
     start() {
+        this.log.debug('Starting lan client for device %s', this.device.deviceid);
+
         mdns.on('response', response => this.processDnsResponse(response));
 
         /* Send the initial query */
+        this.sendDnsQuery();
+    }
+
+    /**
+     * Sends a DNS query to discover devices
+     */
+    async sendDnsQuery() {
         mdns.query({
             questions: [
                 {
                     name: '_ewelink._tcp.local',
-                    // type: 'PTR'
-                    // name: 'MacBook.local',
                     type: 'TXT'
+                },
+                {
+                    name: 'eWeLink_' + this.device.deviceid + '.local',
+                    type: 'A'
+                },
+                {
+                    name: 'eWeLink_' + this.device.deviceid + '.local',
+                    type: 'SRV'
                 }
             ]
         });
     }
 
+    /**
+     * Close internal listeners for DNS responses. 
+     */
+    close() {
+        mdns.destroy();
+    }
 
+    /**
+     * Process a DNS response and look for this device. 
+     * 
+     * TODO: this could call back to update homebridge with updated
+     * device states
+     * 
+     * @param {*} response the DNS response from the mdns client
+     */
     processDnsResponse(response) {
+
+        //TODO: Need some way of determining when a device goes away
 
         /* find the item for the device */
         if (response.answers) {
             response.answers
-                .filter(value => value.name === this.deviceName && value.type === 'TXT')
+                .filter(value => value.name === this.deviceName)
                 .forEach(value => {
-                    this.log.debug('got a matching response for device %s: %o',
-                        this.device.deviceid, value)
+                    // this.log.debug('DNS Response: %o', response);
 
-                    let dataObject = {};
+                    if (value.type === 'TXT') {
+                        /* TXT records contain the state for the device */
 
-                    value.data.forEach(dataValue => {
-                        this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
+                        // this.log.debug('got a matching response for device %s: %o',
+                        //     this.device.deviceid, value)
 
-                        let bufferString = dataValue.toString('utf-8');
-                        let key = bufferString.substr(0, bufferString.indexOf('='));
+                        const processedDeviceResponse = Object.assign({}, value);
 
-                        dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
-                    });
+                        let dataObject = {};
 
-                    this.log.debug('DNS txt record for device %s is: %o',
-                        this.device.deviceid, dataObject);
+                        value.data.forEach(dataValue => {
+                            // this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
 
-                    
-                    /* Turn this TXT record into something usable for the state */
-                    const stateData = this.extractDataFromDnsService(dataObject, this.device.devicekey);
-                    this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
+                            let bufferString = dataValue.toString('utf-8');
+                            let key = bufferString.substr(0, bufferString.indexOf('='));
+
+                            dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
+                        });
+
+                        // this.log.debug('DNS txt record for device %s is: %o',
+                        //     this.device.deviceid, dataObject);
+                        processedDeviceResponse.data = dataObject;
+
+
+                        /* Turn this TXT record into something usable for the state */
+                        const stateData = this.extractDataFromDnsService(dataObject, this.device.devicekey);
+                        // this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
+                        processedDeviceResponse.data.state = stateData;
+
+                        this.localDevice = processedDeviceResponse;
+
+                        this.log.debug('LocalDevice state for %s is: %o', this.device.deviceid, this.localDevice);
+                    } else if (value.type === 'SRV') {
+                        /* A record contains the host details we need to invoke an API */
+                        this.log.debug('DNS SRV answer: %o', value);
+
+                        this.localDeviceHost = {
+                            host: value.data.target,
+                            port: value.data.port
+                        };
+
+                        this.log.debug('LocalDevice host for %s is: %o', this.device.deviceid, this.localDeviceHost);
+                    } else {
+                        this.log.debug('Unhandled device DNS answer: %o', value);
+                    }
                 });
-
         }
+
     }
 
+    /**
+     * Get the details of the local device state. 
+     */
+    getLocalDevice() {
+
+        /* If anything requests information on the local device, then
+         * kick off a new DNS query to ensure we are up to date 
+         */
+        this.sendDnsQuery();
+
+        return this.localDevice;
+    }
 
     /**
      * Decrypt the supplied data. 
@@ -126,7 +200,7 @@ module.exports = class LanClient {
             iv: iv,
         };
 
-    };
+    }
 
     /**
      * Extract the state data object from the MDNS service.
@@ -188,48 +262,42 @@ module.exports = class LanClient {
 
         /* Convert to a JSON object */
         return (data ? JSON.parse(data) : undefined);
-    };
+    }
 
     /**
     * Method to perform an API call to the device. This handles aspects of wrapping
     * the supplied data object with the result of the payload information. 
     * This will always make http requests. 
-    * @param log the logger instance to use for log messages
-    * @param host the host to send the request to
-    * @param port the port to send the request to. 
+    *  
     * @param path the path to send the request to
-    * @param deviceId the device identifier
     * @param data the data object containing the state to send to the device. The surrounding 
     *             payload fields are all handled by this method.
-    * @param apiKey the device API key. This optional parameter should only be supplied when
-    *               performing an operation against a device which is not in DIY mode and so
-    *               requires encrypted payloads to be sent. 
     */
-    async doApiCall(log, host, port, path, deviceId, data, apiKey) {
+    async doApiCall(path, data) {
 
         const payload = {
             sequence: Date.now().toString(),
             selfApikey: '123',
-            deviceid: deviceId,
+            deviceid: this.device.deviceid,
             data: JSON.stringify(data),
             encrypt: false,
         };
 
 
-        log.debug('Pre-encryption payload: %s', JSON.stringify(payload));
+        this.log.debug('Pre-encryption payload: %s', JSON.stringify(payload));
 
-        if (apiKey) {
+        if (this.localDevice.data.encrypt) {
             /* if we have an API key, need to encrypt the data */
             payload.encrypt = true;
 
-            const encryptionResult = encrypt(payload.data, apiKey);
+            const encryptionResult = this.encrypt(payload.data, this.device.devicekey);
             payload.data = encryptionResult.data.toString('base64');
             payload.iv = encryptionResult.iv.toString('base64');
         }
 
-        let connectionHost = 'http://' + host;
-        if (port) {
-            connectionHost += ':' + port;
+        let connectionHost = 'http://' + this.localDeviceHost.host;
+        if (this.localDeviceHost.port) {
+            connectionHost += ':' + this.localDeviceHost.port;
         }
 
         let webClient = request.createClient(connectionHost);
@@ -238,9 +306,81 @@ module.exports = class LanClient {
         webClient.headers['Accept-Language'] = 'en-gb';
 
         /* Return the promise for the request */
+        this.log.debug('Sending call to path: %s', path);
         return webClient.post(path, payload);
     }
 
+    /**
+     * Get the switch status of the current local device. 
+     * 
+     * @returns boolean of the switch status, or undefined if the device is not of the plug type
+     */
+    getSwitchStatus() {
 
+        this.log.debug('lanClient getSwitchStatus');
+
+        let result = undefined;
+        if (this.localDevice && this.localDevice.data.type === 'plug') {
+            result = this.localDevice.data.state.switch === 'on';
+        }
+
+        this.log.debug('lanClient getSwitchStatus result: %s', result);
+        return result;
+    }
+
+    /**
+     * 
+     * @param accessory the accessory being updated
+     * @param on boolean to indicate if the device should be sent an
+     *           'on' (true) or 'off' (false) state.
+     * @param callback the function to call after the update has been applied 
+     */
+    setSwitchStatus(accessory, on, callback) {
+
+        this.log.debug('Lan mode setSwitchStatus for %s to %o', accessory.displayName, on);
+  
+        const data = {
+            switch: (on ? 'on': 'off'),
+        };
+    
+        this.doApiCall('/zeroconf/switch', data)
+            .then(response => {
+                // this.log.debug('Device response: %o', response);
+
+                this.log.debug('Device response body: %o', response.body);
+
+                if (response.body.error === 0) {
+                    callback(null, on);
+                } else {
+                    callback('Error from the device API, code: ' + response.body.error);
+                }
+
+                
+            })
+            .catch(error => {
+                this.log.error('Error updating device: %s', error);
+                callback(error);
+            })
+    
+    }
+
+    /**
+     * Get the power state for a single outlet in a strip
+     * @param {int} outlet the outlet index to get the state for. This is zero indexed. 
+     * 
+     * @returns boolean of the switch status, or undefined if the device is not of the strip type
+     */
+    getStripOutletStatus(outlet) {
+
+        this.log.debug('lanClient getStripOutletStatus %s', outlet);
+
+        let result = undefined;
+        if (this.localDevice && this.localDevice.data.type === 'strip') {
+            result = this.localDevice.data.state.switches[outlet].switch === 'on';
+        }
+
+        this.log.debug('lanClient getStripOutletStatus result: %s', result);
+        return result;
+    }
 
 }

--- a/lib/sonoffLanModeApi.js
+++ b/lib/sonoffLanModeApi.js
@@ -1,7 +1,10 @@
-let request = require('request-json');
-let crypto = require('crypto');
-
+const crypto = require('crypto');
+const EventEmitter = require('events');
 const mdns = require('multicast-dns')()
+const request = require('request-json');
+
+const Cache = require('./cache');
+
 
 
 /**
@@ -9,10 +12,10 @@ const mdns = require('multicast-dns')()
  * multicast DNS. 
  * 
  * TODO: 
- * - Change so "get" requests use promises, return the decrypted device state.
- *   This means it can be used the same way as the WebSocket and HTTP clients. 
  * - Also needs a way to keep a handle on if a device supports LAN mode
  *   This is the current TODO
+ * - Need some way of determining when a device goes away
+ * 
  */
 module.exports = class LanClient {
 
@@ -21,17 +24,42 @@ module.exports = class LanClient {
     /**
      * Create a new LanClient. 
      * @param {*} log the logger instance to use for log messages
+     * @param {*} config the plugin configuration
      */
-    constructor(log) {
+    constructor(log, config) {
 
         this.log = log;
 
         /**
-         * Map of deviceId to their last known DNS state. 
+         * Cache holding deviceId to an object holding the host & port 
+         * for the device. 
          * 
-         * TODO: interval clearing this out after a TTL?
+         * This is set to cache, by default, to 3 minutes. 
          */
-        this.deviceMap = new Map();
+        this.deviceHostMap = new Cache(log, (180 * 1000));
+        this.deviceHostMap.addCacheExpiryListener((deviceId) => {
+            /* If we are told a device has been removed from the cache, 
+             * send a notification that the device is offline.
+             */
+
+             const notification = {
+                 action: 'sysmsg',
+                 deviceid: deviceId,
+                 params: {
+                     online: false
+                 }
+             };
+
+             this.eventEmitter.emit('state', notification);
+        });
+
+        /**
+         * Cache for holding deviceId to an object holding 
+         * the status information for a device. 
+         * 
+         * This is set to cache, by default, to 10 seconds
+         */
+        this.deviceStatusMap = new Cache(log, (10 * 1000));
 
         /**
          * Map of deviceId to their corresponding deviceKey.
@@ -39,6 +67,132 @@ module.exports = class LanClient {
          */
         this.deviceKeyMap = new Map();
 
+        /* DNS timeout used when getting the status for a device (in milliseconds) */
+        this.dnsTimeout = 3000;
+
+        /* Parse the lan client configuration */
+        this._parseConfig(config.experimentalLanClient);
+
+        /* Add an event emmitter for events */
+        this.eventEmitter = new EventEmitter();
+
+        /* Startup the client background processes */
+        setTimeout(() => this._start(), 10);
+
+    }
+
+    /**
+     * The configuration for the LAN client can take two forms:
+     * 1. a boolean true/false
+     * 2. an object holding additional settings
+     * 
+     * We need to parse this configuration to set various configuration values. 
+     * 
+     * @param {*} config the lan client configuration to process. 
+     */
+    _parseConfig(config) {
+
+        this.log.debug('Lan Client Configuration is a %s', typeof config);
+
+        if ('object' === typeof config) {
+            /* Is a configuration object, get some fields */
+            this.logDnsResponses = (config.logDnsResponses === true);
+        }
+    }
+
+    /**
+     * Sends a DNS query to discover devices
+     */
+    _sendDnsQuery() {
+
+        let questions = [
+            {
+                name: '_ewelink._tcp.local',
+                type: 'SRV'
+            }
+        ];
+
+        // Iterate through known devices and add them to the queries to get the SRV & A records
+        const deviceIds = new Set(this.deviceHostMap.keys());
+
+        this.log.debug('Device Key Map: %o', this.deviceKeyMap.keys());
+
+        Array.from(this.deviceKeyMap.keys()).forEach(key => deviceIds.add(key));
+        deviceIds.forEach(key => {
+            const hostName = 'eWeLink_' + key + '.local';
+            questions.push(
+                {
+                    name: hostName,
+                    type: 'SRV'
+                }
+            );
+            questions.push(
+                {
+                    name: hostName,
+                    type: 'TXT'
+                }
+            );
+        });
+        
+            
+
+        mdns.query({
+            questions: questions
+        }, () => {
+            if (this.logDnsResponses) {
+                this.log.debug('Query sent for questions: %o', questions);
+            }
+        });
+    }
+
+    /**
+     * Register internal listeners and make an initial query to attempt local discovery of the device. 
+     */
+    _start() {
+        this.log.debug('Starting lan client');
+
+        mdns.on('response', response => {
+            /* Only want to process 'ewelink' responses */
+            if (response.answers) {
+                response.answers
+                    .filter(value => value.name.startsWith('eWeLink_'))
+                    .forEach(value => this.processDnsResponse(value, true));
+            }
+        });
+
+        /* Send an initial DNS query, then repeat every 2 minutes (120 s) */
+        this._sendDnsQuery();
+        setInterval(() => this._sendDnsQuery(), (120 * 1000));
+    }
+
+    /**
+     * Get a status object created from the caches. 
+     * @param {string} deviceId the id of the device to get the status from
+     * @param object holding the host and status if both are currently held 
+     *               in the cache, otherwise undefined will be returned. 
+     */
+    _getCachedStatusForDevice(deviceId) {
+        
+        let status;
+        
+        /* Check if we have the details we need in the cache */
+        let cachedDeviceStatus = this.deviceStatusMap.get(deviceId);
+        let cachedDeviceHost = this.deviceHostMap.get(deviceId);
+
+        if (cachedDeviceStatus && cachedDeviceHost) {
+            /* Both values exist in the cache, build the object and return */
+            status = {
+                params: cachedDeviceStatus,
+                host: cachedDeviceHost.host
+            };
+
+            this.log.debug('Returning cached item for device %s: %o', deviceId, status);
+        } else {
+            this.log.debug('Cache miss for device %s, cached items were: %s/%s', 
+                deviceId, cachedDeviceStatus, cachedDeviceHost);
+        }
+
+        return status;
     }
 
     /**
@@ -49,45 +203,18 @@ module.exports = class LanClient {
     addDeviceKey(deviceId, deviceKey) {
         this.log.debug('Adding device key %s for device %s', deviceKey, deviceId);
         this.deviceKeyMap.set(deviceId, deviceKey);
+
+        /* If a device key is being added, make another DNS query to update any
+         * details we may have failed to decode */
+        this._sendDnsQuery();
     }
 
     /**
-     * Register internal listeners and make an initial query to attempt local discovery of the device. 
+     * Add a listener to be called when the state of a device changes. 
+     * @param {function} funct the function to be called when events occur. 
      */
-    start() {
-        this.log.debug('Starting lan client');
-
-        mdns.on('response', response => this.processDnsResponse(response));
-
-        /* Send the DNS queries every 5 minutes (300 s) */
-        setInterval(() => this.sendDnsQuery(), (300 * 1000));
-    }
-
-    /**
-     * Sends a DNS query to discover devices
-     */
-    sendDnsQuery() {
-
-        let questions = [
-            {
-                name: '_ewelink._tcp.local',
-                type: 'TXT'
-            }
-        ];
-
-        //TODO: Iterate through known devices and add them to the queries
-        //{
-            //     name: 'eWeLink_' + this.device.deviceid + '.local',
-            //     type: 'A'
-            // },
-            // {
-            //     name: 'eWeLink_' + this.device.deviceid + '.local',
-            //     type: 'SRV'
-            // }
-
-        mdns.query({
-            questions: questions
-        });
+    addDeviceStateListener(funct) {
+        this.eventEmitter.addListener('state', funct);
     }
 
     /**
@@ -98,104 +225,106 @@ module.exports = class LanClient {
     }
 
     /**
-     * Process a DNS response and look for this device. 
+     * Process a single eWelink DNS response answer. 
      * 
      * TODO: this could call back to update homebridge with updated
      * device states
+     * Needs to have an event and send the update type. 
      * 
-     * @param {*} response the DNS response from the mdns client
+     * @param {*} value the DNS response answer from the mdns client
+     * @param {boolean} notify if true is supplied, this will trigger "sysmsg" device status events.
+     * @returns the processed object
      */
-    processDnsResponse(response) {
+    processDnsResponse(value, notify = false) {
 
-        //TODO: Need some way of determining when a device goes away
-
-        /* find the item for the device */
-        if (response.answers) {
-            response.answers
-                .filter(value => value.name.startsWith('eWeLink_'))
-                // .filter(value => value.name === this.deviceName)
-                .forEach(value => {
-                    // this.log.debug('DNS Response: %o', response);
-
-                    /* Get the deviceId from the device name */
-                    let deviceId = value.name.substr(8, 10);
-                    this.log.debug('parsedDeviceId for name %s is %s. Record type %s', value.name, deviceId, value.type);
-
-                    let status = this.deviceMap.get(deviceId);
-                    if (!status) {
-                        /* Need to create the object to put in the map */
-                        status = {};
-                    }
-
-                    /* TODO: Solve duplication with getDeviceStatus, possibly just look for SRV records
-                     *        here, and use that to trigger a call to getDeviceStatus?
-                     */ 
-                    if (value.type === 'TXT') {
-                        /* TXT records contain the state for the device */
-
-                        // this.log.debug('got a matching response for device %s: %o',
-                        //     this.device.deviceid, value)
-
-                        const processedDeviceResponse = Object.assign({}, value);
-
-                        let dataObject = {};
-
-                        value.data.forEach(dataValue => {
-                            // this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
-
-                            let bufferString = dataValue.toString('utf-8');
-                            let key = bufferString.substr(0, bufferString.indexOf('='));
-
-                            dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
-                        });
-
-                        // this.log.debug('DNS txt record for device %s is: %o',
-                        //     this.device.deviceid, dataObject);
-                        processedDeviceResponse.data = dataObject;
-
-
-                        /* Turn this TXT record into something usable for the state */
-                        const stateData = this.extractDataFromDnsService(dataObject, 
-                            this.deviceKeyMap.get(dataObject.id));
-                        // this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
-
-                        status.params = stateData;
-                        status.txt = processedDeviceResponse;
-
-                        this.log.debug('LocalDevice state for %s is: %o', deviceId, status.params);
-                    } else if (value.type === 'SRV') {
-                        /* A record contains the host details we need to invoke an API */
-                        this.log.debug('DNS SRV answer: %o', value);
-
-                        status.host = {
-                            host: value.data.target,
-                            port: value.data.port
-                        };
-                        
-                        status.srv = value;
-
-                        this.log.debug('LocalDevice host for %s is: %o', deviceId, status.host);
-                    } else {
-                        this.log.debug('Unhandled device DNS answer: %o', value);
-                    }
-
-                    this.deviceMap.set(deviceId, status);
-                });
+        /* Get the deviceId from the device name */
+        let deviceId = value.name.substr(8, 10);
+        if (this.logDnsResponses) {
+            this.log.debug('parsedDeviceId for name %s is %s. Record type %s', 
+                value.name, deviceId, value.type);
         }
 
-    }
 
-    /**
-     * Get the details of the local device state. 
-     */
-    getLocalDevice() {
+        let processedDeviceResponse;
+        if (value.type === 'TXT') {
+            /* TXT records contain the state for the device */
 
-        /* If anything requests information on the local device, then
-         * kick off a new DNS query to ensure we are up to date 
-         */
-        this.sendDnsQuery();
+            if (this.logDnsResponses) {
+                this.log.debug('DNS txt record for device %s is: %o',
+                    deviceId, value);
+            }
 
-        return this.localDevice;
+            processedDeviceResponse = Object.assign({}, value);
+
+            let dataObject = {};
+
+            value.data.forEach(dataValue => {
+                // this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
+
+                let bufferString = dataValue.toString('utf-8');
+                let key = bufferString.substr(0, bufferString.indexOf('='));
+
+                dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
+            });
+
+            processedDeviceResponse.data = dataObject;
+
+
+            /* Turn this TXT record into something usable for the state */
+            const stateData = this.extractDataFromDnsService(dataObject, 
+                this.deviceKeyMap.get(dataObject.id));
+
+            processedDeviceResponse.params = stateData;
+
+            this.log.debug('State data for device %s is: %o', 
+                deviceId, processedDeviceResponse.params);
+
+            /* if we are to notify, check if we have a current status, and notify if it differs */
+            if (notify) {
+                const lastKnownState = this.deviceStatusMap.get(deviceId);
+
+                if (!lastKnownState || lastKnownState !== stateData) {
+                    this.log.debug('State has changed for device %s. Old state: %s, new state %s', 
+                        deviceId, lastKnownState, stateData);
+
+                    const notificationMessage = {
+                        action: 'update',
+                        deviceid: deviceId,
+                        online: true,
+                        params: stateData
+                    };
+                    notificationMessage.params.online = true;
+
+                    this.log.debug('Notification message would be: %o', notificationMessage);
+                    this.eventEmitter.emit('state', notificationMessage);
+                }
+            }
+
+            /* Add to the cache */
+            this.deviceStatusMap.set(deviceId, stateData);
+        } else if (value.type === 'SRV') {
+            /* A record contains the host details we need to invoke an API */
+            if (this.logDnsResponses) {
+                this.log.debug('DNS SRV answer: %o', value);
+            }
+
+            processedDeviceResponse = {
+                host: {
+                    host: value.data.target,
+                    port: value.data.port
+                },
+                srv: value
+            };
+
+            this.log.debug('Host details for %s is: %o', deviceId, processedDeviceResponse);
+
+            /* Add the host details to a cache */
+            this.deviceHostMap.set(deviceId, processedDeviceResponse);
+        } else if (this.logDnsResponses) {
+            this.log.debug('Unhandled device DNS answer: %o', value);
+        }
+
+        return processedDeviceResponse;
     }
 
     /**
@@ -203,98 +332,119 @@ module.exports = class LanClient {
      * 
      * This comes from a combination of a few DNS responses.
      * 
-     * @param {*} deviceId 
-     * @param {*} deviceKey
+     * @param {*} deviceId the id of the device to get the status for
      * @returns a promise. This will return the single device from the API call, 
      *          or throw an Error if it cannot be found. 
      */
-    getDeviceStatus(deviceId, deviceKey) {
+    getDeviceStatus(deviceId) {
 
         return new Promise((resolve, reject) => {
-            let deviceName = 'eWeLink_' + deviceId + '._ewelink._tcp.local';
-            this.log.debug('TEST LOG: %s', deviceName);
 
-            // const mdnsClient = multicastdns();
-            const mdnsClient = require('multicast-dns')();
-            let status = {};
+            /* Check if we have the details we need in the cache */
+            let status = this._getCachedStatusForDevice(deviceId);
 
-            mdnsClient.on('response', response => {
-                if (response.answers) {
-                    response.answers
-                        .filter(value => value.name === deviceName)
-                        .forEach(value => {
-                            this.log.debug('DNS Response: %o', response);
-        
-                            if (value.type === 'TXT') {
-                                const processedDeviceResponse = Object.assign({}, value);
+            if (status) {
+                /* Exists in the cache, return */
+                this.log.debug('Returning cached result for device %s: %o', deviceId, status);
 
-                                let dataObject = {};
+                resolve(status);
 
-                                value.data.forEach(dataValue => {
-                                    // this.log.debug('Buffer string: %s', dataValue.toString('utf-8'))
+            } else {
+                /* Need to lookup the information, but start the object with a host (if we have it cached) */
+                this.log.debug('Looking up status for device %s', deviceId);
+                status = {};
 
-                                    let bufferString = dataValue.toString('utf-8');
-                                    let key = bufferString.substr(0, bufferString.indexOf('='));
-
-                                    dataObject[key] = bufferString.substr(bufferString.indexOf('=') + 1);
-                                });
-
-                                // this.log.debug('DNS txt record for device %s is: %o',
-                                //     this.device.deviceid, dataObject);
-                                processedDeviceResponse.data = dataObject;
-
-
-                                /* Turn this TXT record into something usable for the state */
-                                const stateData = this.extractDataFromDnsService(dataObject, 
-                                    this.deviceKeyMap.get(dataObject.id));
-                                // this.log.debug('State data for device %s is: %o', this.device.deviceid, stateData);
-                                status.params = stateData;
-
-                                status.txt = processedDeviceResponse;
-                            } else if (value.type === 'SRV') {
-                                /* Store the whole SRV record */
-                                status.srv = value;
-
-                                /* Store a value with the parsed out information we need to connect */
-                                status.host = {
-                                    host: value.data.target,
-                                    port: value.data.port
-                                };
-
-                            } else {
-                                this.log.debug('Unhandled device DNS answer: %o', value);
-                            }
-
-                            if (status.srv && status.txt) {
-                                resolve(status);
-                                mdnsClient.destroy();
-                            }
-                        });
+                let cachedDeviceHost = this.deviceHostMap.get(deviceId);
+                if (cachedDeviceHost) {
+                    status.host = cachedDeviceHost.host;
                 }
-            });
 
-            mdnsClient.query({
-                questions: [
-                    {
-                        name: '_ewelink._tcp.local',
-                        type: 'TXT'
-                    },
+                /* The device name that will be included in DNS responses, 
+                 * we need to match the incoming reponses to this */
+                const deviceName = 'eWeLink_' + deviceId + '._ewelink._tcp.local';
+                this.log.debug('TEST LOG: %s', deviceName);
+
+                /* Configure the MDNS client */
+                const mdnsClient = require('multicast-dns')();
+
+                /* We don't want to wait for long, so reject the promise after a period of time */
+                const timerId = setTimeout(() => {
+                    mdnsClient.destroy();
+
+                    this.log.debug('DNS request timed out for %s, current status: %o', deviceId, status);
+
+                    /* Check one last time to see if we have now got a cached value to return */
+                    status = this._getCachedStatusForDevice(deviceId);
+                    if (status) {
+                        this.log.debug('DNS request timed out for device %s, but cached value now found.',
+                            deviceId);
+                        resolve(status);
+                    } else {
+                        reject('DNS request timed out for device ' + deviceId);
+                    }
+                }, this.dnsTimeout);
+
+                /* Configure the listener we use to look for our responses and resolve the promise */
+                mdnsClient.on('response', response => {
+                    if (response.answers) {
+                        response.answers
+                            .filter(value => value.name === deviceName)
+                            .forEach(value => {
+                                if (this.logDnsResponses) {
+                                    this.log.debug('DNS Response: %o', value);
+                                }
+            
+                                if (value.type === 'TXT') {
+
+                                    const txt = this.processDnsResponse(value);
+                                    if (this.logDnsResponses) {
+                                        this.log.debug('Processed TXT record for %s: %o', deviceId, txt);
+                                    }
+                                    status.params = txt.params;
+
+                                } else if (value.type === 'SRV') {
+                                    
+                                    /* Store a value with the parsed out information we need to connect */
+                                    const srv = this.processDnsResponse(value);
+                                    if (this.logDnsResponses) {
+                                        this.log.debug('Processed SRV record for %s: %o', deviceId, srv);
+                                    }
+                                    status.host = srv.host;
+                                    
+                                } else {
+                                    this.log.debug('Unhandled device DNS answer: %o', value);
+                                }
+
+                                if (status.host && status.params) {
+                                    /* Resolve the promise */
+                                    resolve(status);
+                                    /* Clean up */
+                                    mdnsClient.destroy();
+                                    clearTimeout(timerId);
+                                }
+                            });
+                    }
+                });
+
+                /* Perform the DNS query */
+                const questions = [
                     {
                         name: 'eWeLink_' + deviceId + '.local',
-                        type: 'A'
+                        type: 'TXT'
                     },
                     {
                         name: 'eWeLink_' + deviceId + '.local',
                         type: 'SRV'
                     }
-                ]
-            }, () => this.log.debug('DNS QUERY SENT'));
-
-            /* We don't want to wait for long, so reject the promise after a second */
-            setTimeout(() => {
-                mdnsClient.destroy();
-                reject('DNS request timed out for device ' + deviceId);
-            }, 1000);
+                ];
+                mdnsClient.query({
+                    questions: questions
+                }, () => {
+                    if (this.logDnsResponses) {
+                        this.log.debug('DNS QUERY SENT: %o', questions);
+                    }
+                });
+            }
         });
     }
 
@@ -408,7 +558,9 @@ module.exports = class LanClient {
             data = data1;
         }
 
-        this.log.debug('Data: %o', data);
+        if (this.logDnsResponses) {
+            this.log.debug('Data: %o', data);
+        }
 
 
         /* Convert to a JSON object */
@@ -438,18 +590,21 @@ module.exports = class LanClient {
 
         this.log.debug('Pre-encryption payload: %o', payload);
 
-        if (this.localDevice.data.encrypt) {
+        const encryptionKey = this.deviceKeyMap.get(deviceId);
+        if (encryptionKey) {
             /* if we have an API key, need to encrypt the data */
             payload.encrypt = true;
 
-            const encryptionResult = this.encrypt(payload.data, this.deviceKeyMap.get(deviceId));
+            const encryptionResult = this.encrypt(payload.data, encryptionKey);
             payload.data = encryptionResult.data.toString('base64');
             payload.iv = encryptionResult.iv.toString('base64');
         }
 
-        let connectionHost = 'http://' + this.localDeviceHost.host;
-        if (this.localDeviceHost.port) {
-            connectionHost += ':' + this.localDeviceHost.port;
+        /* Configure the connection host string */
+        const localDeviceHost = this.deviceHostMap.get(deviceId);
+        let connectionHost = 'http://' + localDeviceHost.host;
+        if (localDeviceHost.port) {
+            connectionHost += ':' + localDeviceHost.port;
         }
 
         let webClient = request.createClient(connectionHost);
@@ -471,64 +626,36 @@ module.exports = class LanClient {
      *          If this device does not support a lan client, an "Unsupported" 
      *          error will be returned. 
      */
-    async updateDeviceStatus(accessory, statusParams) {
+    updateDeviceStatus(accessory, statusParams) {
 
 
-        let path;
-        if (statusParams.switch) {
-            /* Single switch device */
-            path = '/zeroconf/switch';
-        } else if (statusParams.switches) {
-            /* Multiple Switch Device */
-            path = '/zeroconf/switches';
-        }
+        return new Promise((resolve, reject) => {
+            /* Based on the status supplied, work out the API to call */
+            let path;
+            if (statusParams.switch) {
+                /* Single switch device */
+                path = '/zeroconf/switch';
+            } else if (statusParams.switches) {
+                /* Multiple Switch Device */
+                path = '/zeroconf/switches';
+            }
 
 
-        if (!path) {
-            throw new Error("Unsupported");
-        } else {
-            /* Do a lan API call */
-            return await doApiCall(accessory.context.deviceId, path, statusParams);
-        }
+            if (!path) {
+                /* Could not determine the correct path, throw an unsupported error */
+                reject("Unsupported");
+            } else {
+                /* Do a lan API call */
+                doApiCall(accessory.context.deviceId, path, statusParams)
+                    .then(result => {
+                        /* Remove the cached device state */
+                        this.deviceStatusMap.delete(accessory.context.deviceId);
+
+                        /* Return the result */
+                        resolve(result);
+                    }).catch(err => reject(err));
+            }
+        });
         
-
-        
-
-    }
-
-    /**
-     * 
-     * @param accessory the accessory being updated
-     * @param on boolean to indicate if the device should be sent an
-     *           'on' (true) or 'off' (false) state.
-     * @param callback the function to call after the update has been applied 
-     */
-    setSwitchStatus(accessory, on, callback) {
-
-        this.log.debug('Lan mode setSwitchStatus for %s to %o', accessory.displayName, on);
-  
-        const data = {
-            switch: (on ? 'on': 'off'),
-        };
-    
-        this.doApiCall('/zeroconf/switch', data)
-            .then(response => {
-                // this.log.debug('Device response: %o', response);
-
-                this.log.debug('Device response body: %o', response.body);
-
-                if (response.body.error === 0) {
-                    callback(null, on);
-                } else {
-                    callback('Error from the device API, code: ' + response.body.error);
-                }
-
-                
-            })
-            .catch(error => {
-                this.log.error('Error updating device: %s', error);
-                callback(error);
-            })
-    
     }
 }

--- a/lib/webSocketClient.js
+++ b/lib/webSocketClient.js
@@ -257,8 +257,13 @@ module.exports = class WebSocketClient {
             payload.at = this.config.authenticationToken;
             payload = this.populateCommonApiRequestFields(payload);
 
-            /* Introduce a small pause to prevent spamming the websocket */
-            // await this.sleep(200);
+            /* Introduce a small pause to prevent spamming the websocket,
+             * random duration between 200 & 400 ms. 
+            */
+            let delay = (Math.random() * (200)) + 200
+            this.log.debug('Pausing for %s for %s', delay, deviceId);
+            await this.sleep(delay);
+            this.log.debug('After pause for %s', deviceId);
 
             //TODO: Need to add something to stop multiple requests for the same device
 

--- a/lib/webSocketClient.js
+++ b/lib/webSocketClient.js
@@ -1,0 +1,93 @@
+let WebSocket = require('ws');
+
+module.exports = class WebSocketClient {
+
+    /**
+     * Create a new WebSocketClient
+     * @param {*} log the logger instance to use for log messages
+     */
+    constructor(log) {
+
+        this.log = log;
+
+        this.number = 0; // Message number
+        this.autoReconnectInterval = 5 * 1000; // ms
+        this.pendingReconnect = false;
+    }
+    
+    open(url) {
+        this.url = url;
+        this.instance = new WebSocket(this.url);
+        this.instance.on('open', () => {
+            this.onopen();
+        });
+    
+        this.instance.on('message', (data, flags) => {
+            this.number++;
+            this.onmessage(data, flags, this.number);
+        });
+    
+        this.instance.on('close', (e) => {
+            switch (e) {
+                case 1000: // CLOSE_NORMAL
+                    // console.log("WebSocket: closed");
+                    break;
+                default: // Abnormal closure
+                    this.reconnect(e);
+                    break;
+            }
+            this.onclose(e);
+        });
+        this.instance.on('error', (e) => {
+            switch (e.code) {
+                case 'ECONNREFUSED':
+                    this.reconnect(e);
+                    break;
+                default:
+                    this.onerror(e);
+                    break;
+            }
+        });
+    }
+
+    send(data, option) {
+        try {
+            this.instance.send(data, option);
+        } catch (e) {
+            this.instance.emit('error', e);
+        }
+    }
+
+    reconnect(e) {
+        // console.log(`WebSocketClient: retry in ${this.autoReconnectInterval}ms`, e);
+    
+        if (this.pendingReconnect) return;
+        this.pendingReconnect = true;
+    
+        this.instance.removeAllListeners();
+    
+        let platform = this;
+        setTimeout(() => {
+            platform.pendingReconnect = false;
+            platform.log.info("WebSocketClient: reconnecting...");
+            platform.open(platform.url);
+        }, this.autoReconnectInterval);
+    }
+
+    onopen(e) {
+        // console.log("WebSocketClient: open", arguments);
+    }
+
+    onmessage(data, flags, number) {
+        // console.log("WebSocketClient: message", arguments);
+    }
+
+    onerror(e) {
+        this.log.error("WebSocketClient: error", arguments);
+    }
+
+    onclose(e) {
+        // console.log("WebSocketClient: closed", arguments);
+    }
+
+}

--- a/lib/webSocketClient.js
+++ b/lib/webSocketClient.js
@@ -232,25 +232,75 @@ module.exports = class WebSocketClient {
         return crypto.randomBytes(16).toString('base64');
     }
 
-    async getDeviceStatus(deviceId) {
+    getDeviceStatus(deviceId) {
 
-        let cachedDeviceStatus = this.deviceStatusMap.get(deviceId);
+        return new Promise((resolve, reject) => {
 
-        if (cachedDeviceStatus) {
-            this.log.debug('Returning cached status for device %s: %o', 
-                deviceId, cachedDeviceStatus);
-            
-            return cachedDeviceStatus;
-        } else {
-            this.log.debug('Making request for status for device %s', 
-                deviceId);
+            let cachedDeviceStatus = this.deviceStatusMap.get(deviceId);
 
+            if (cachedDeviceStatus) {
+                this.log.debug('Returning cached status for device %s: %o', 
+                    deviceId, cachedDeviceStatus);
+                
+                resolve(cachedDeviceStatus);
+            } else {
+                this.log.debug('Making request for status for device %s', 
+                    deviceId);
+
+                let payload = {
+                    action: 'query',
+                    apikey: this.config.apiKey,
+                    deviceid: deviceId,
+                    userAgent: 'app',
+                    params: []
+                };
+
+                /* Extra undocumented params */
+                payload.at = this.config.authenticationToken;
+                payload = this.populateCommonApiRequestFields(payload);
+
+                /* Introduce a small pause to prevent spamming the websocket,
+                * random duration between 200 & 400 ms. 
+                */
+                let delay = (Math.random() * (200)) + 200
+                this.log.debug('Pausing for %s for %s', delay, deviceId);
+                this.sleep(delay).then(() => {
+                    this.log.debug('After pause for %s', deviceId);
+
+                    //TODO: Need to add something to stop multiple requests for the same device
+
+                    this.instance.sendRequest(payload, {
+                            requestId: this.getSequence()
+                        }).then(result => {
+                            /* Add to the cache */
+                            this.deviceStatusMap.set(deviceId, result);
+
+                            /* Set a timer to remove the item from the cache */
+                            setInterval(() => {
+                                this.deviceStatusMap.delete(deviceId);
+                            }, this.cacheDuration);
+
+                            /* Return */
+                            resolve(result);
+                        }).catch(err => reject(err));
+                });
+            }
+        });
+    }
+
+    updateDeviceStatus(deviceId, params) {
+
+        return new Promise((resolve, reject) => {
+
+            /* Documentation says action value should be 'action:update', this is
+            * incorrect, should just be 'update'
+            */
             let payload = {
-                action: 'query',
+                action: 'update',
                 apikey: this.config.apiKey,
                 deviceid: deviceId,
                 userAgent: 'app',
-                params: []
+                params: params
             };
 
             /* Extra undocumented params */
@@ -258,49 +308,30 @@ module.exports = class WebSocketClient {
             payload = this.populateCommonApiRequestFields(payload);
 
             /* Introduce a small pause to prevent spamming the websocket,
-             * random duration between 200 & 400 ms. 
+            * random duration between 200 & 400 ms. 
             */
             let delay = (Math.random() * (200)) + 200
             this.log.debug('Pausing for %s for %s', delay, deviceId);
-            await this.sleep(delay);
-            this.log.debug('After pause for %s', deviceId);
+            this.sleep(delay).then(() => {
+                this.log.debug('After pause for %s', deviceId);
 
-            //TODO: Need to add something to stop multiple requests for the same device
-
-            //TODO: Add storing details in the cache here
-            return this.instance.sendRequest(payload, {
-                requestId: this.getSequence()
-            });//.then(result => {
-            //     /* Add to the cache */
-            //     this.deviceStatusMap.set(deviceId, result);
-
-            //     /* Set a timer to remove the item from the cache */
-            //     setInterval(() => {
-            //         this.deviceStatusMap.delete(deviceId);
-            //     }, this.cacheDuration);
-            // });
-        }
-    }
-
-    async updateDeviceStatus(deviceId, params) {
-
-        /* Documentation says action value should be 'action:update', this is
-         * incorrect, should just be 'update'
-         */
-        let payload = {
-            action: 'update',
-            apikey: this.config.apiKey,
-            deviceid: deviceId,
-            userAgent: 'app',
-            params: params
-        };
-
-        /* Extra undocumented params */
-        payload.at = this.config.authenticationToken;
-        payload = this.populateCommonApiRequestFields(payload);
-
-        return this.instance.sendRequest(payload, {
-            requestId: this.getSequence()
+                if (this.socketOpen) {
+                    /* Send the request */
+                    this.instance.sendRequest(payload, 
+                            { requestId: this.getSequence() }
+                        ).then(result => resolve(result)
+                        ).catch(err => reject(err));
+                } else {
+                    platform.log("[%s] Socket was closed. Retrying in 5 sec...", deviceId);
+                    setTimeout(() => {
+                        /* Send the request */
+                        this.instance.sendRequest(payload, 
+                            { requestId: this.getSequence() }
+                        ).then(result => resolve(result)
+                        ).catch(err => reject(err));
+                    }, 5000);
+                }
+            });
         });
 
     }
@@ -321,5 +352,56 @@ module.exports = class WebSocketClient {
           setTimeout(resolve, ms);
         });
     } 
+
+    //TODO: PREVIOUS SEND IMPLEMENTATION
+    // May need to look at the delay approach here again
+    // eWeLink.prototype.sendWebSocketMessage = function (string, callback) {
+    //     let platform = this;
+    
+    //     if (!platform.hasOwnProperty('delaySend')) {
+    //         platform.delaySend = 0;
+    //     }
+    //     const delayOffset = 280;
+    
+    //     let sendOperation = function (string) {
+    //         if (!platform.isSocketOpen) {
+    //             // socket not open, retry later
+    //             setTimeout(function () {
+    //                 sendOperation(string);
+    //             }, delayOffset);
+    //             return;
+    //         }
+    
+    //         if (platform.wsc) {
+    //             platform.wsc.send(string);
+    //             //platform.log("WS message sent");
+    //             callback();
+    //         }
+    
+    //         if (platform.delaySend <= 0) {
+    //             platform.delaySend = 0;
+    //         } else {
+    //             platform.delaySend -= delayOffset;
+    //         }
+    //     };
+    
+    //     if (!platform.isSocketOpen) {
+    //         platform.log('Socket was closed. It will reconnect automatically');
+    
+    //         let interval;
+    //         let waitToSend = function (string) {
+    //             if (platform.isSocketOpen) {
+    //                 clearInterval(interval);
+    //                 sendOperation(string);
+    //             } else {
+    //                 //platform.log('Connection not ready.....');
+    //             }
+    //         };
+    //         interval = setInterval(waitToSend, 750, string);
+    //     } else {
+    //         setTimeout(sendOperation, platform.delaySend, string);
+    //         platform.delaySend += delayOffset;
+    //     }
+    // };
 
 }

--- a/lib/webSocketClient.js
+++ b/lib/webSocketClient.js
@@ -1,33 +1,77 @@
-let WebSocket = require('ws');
+const crypto = require('crypto');
+const WebSocket = require('ws');
+const WebSocketAsPromised = require('websocket-as-promised');
 
 module.exports = class WebSocketClient {
 
     /**
      * Create a new WebSocketClient
      * @param {*} log the logger instance to use for log messages
+     * @param {*} config the plugin configuration
      */
-    constructor(log) {
+    constructor(log, config) {
 
         this.log = log;
+        this.config = config;
 
         this.number = 0; // Message number
         this.autoReconnectInterval = 5 * 1000; // ms
         this.pendingReconnect = false;
+
+        this.socketOpen = false;
+    }
+
+    isSocketOpen() {
+        return this.socketOpen;
     }
     
     open(url) {
         this.url = url;
-        this.instance = new WebSocket(this.url);
-        this.instance.on('open', () => {
+
+        this.instance = new WebSocketAsPromised(this.url, {
+            /* Need to configure this to use the 'ws' module
+             * for the websocket interaction
+             */
+            createWebSocket: socketUrl => new WebSocket(socketUrl),
+            extractMessageData: event => event, // <- this is important
+            /* API requests and responses use a "sequence" field we can use
+             * attach the requestId to this field. 
+             */
+            attachRequestId: (data, requestId) => Object.assign({sequence: requestId}, data),
+            extractRequestId: data => data && data.sequence,
+
+            /* Need to specify how JSON is serialized */
+            packMessage: data => {
+                this.log.debug('packMessage message: %o', data);
+                return JSON.stringify(data);
+            },
+            unpackMessage: data => {
+                this.log.debug('unpackMessage message: %o', data);
+                if (data === 'pong') {
+                    /* Heartbeat response, just return as-is */
+                    return data;
+                } else {
+                    /* Convert into an object */
+                    return JSON.parse(data);
+                }
+            }
+        });
+        this.instance.open();
+
+        // this.instance = new WebSocket(this.url);
+        // this.instance.on('open', () => {
+        this.instance.onOpen.addListener(() => {
             this.onopen();
         });
     
-        this.instance.on('message', (data, flags) => {
+        // this.instance.on('message', (data, flags) => {
+        this.instance.onSend.addListener(data => {
             this.number++;
-            this.onmessage(data, flags, this.number);
+            this.onmessage(data, this.number);
         });
     
-        this.instance.on('close', (e) => {
+        // this.instance.on('close', (e) => {
+        this.instance.onClose.addListener(e => {
             switch (e) {
                 case 1000: // CLOSE_NORMAL
                     // console.log("WebSocket: closed");
@@ -36,9 +80,19 @@ module.exports = class WebSocketClient {
                     this.reconnect(e);
                     break;
             }
+            platform.log("WebSocket was closed. Reason [%s]", e);
+            
+            /* Close the 'ping' timer */
+            this.socketOpen = false;
+            if (this.pingInterval) {
+                clearInterval(this.pingInterval);
+                this.pingInterval = null;
+            }
+
             this.onclose(e);
         });
-        this.instance.on('error', (e) => {
+        // this.instance.on('error', (e) => {
+        this.instance.onError.addListener(e => {
             switch (e.code) {
                 case 'ECONNREFUSED':
                     this.reconnect(e);
@@ -76,9 +130,74 @@ module.exports = class WebSocketClient {
 
     onopen(e) {
         // console.log("WebSocketClient: open", arguments);
+
+        this.isSocketOpen = true;
+
+        // We need to authenticate upon opening the connection
+
+        // Here's the eWeLink payload as discovered via Charles
+        let payload = {};
+        payload.action = "userOnline";
+        payload.userAgent = 'app';
+        payload.apkVesrion = "1.8";
+        payload.at = this.config.authenticationToken;
+        payload.apikey = this.config.apiKey;
+        payload.sequence = this.getSequence();
+
+        payload = this.populateCommonApiRequestFields(payload);
+
+        let string = JSON.stringify(payload);
+
+        this.log.debug('Sending login request [%s]', string);
+
+        // this.send(string);
+        this.instance.sendRequest(payload, {
+            requestId: this.getSequence()
+        }).then(response => {
+            this.log.debug('Login websocket response: %o', response);
+
+            /* There is some configuration values we should look at */
+            if (response.config) {
+                this.hbInterval = response.config.hbInterval;
+
+                if (response.config.hb && response.config.hbInterval) {
+                    /* Configure a 'ping' poll to keep alive the connection.
+                     * API docs say to add 7 to this and use as the interval.
+                    */
+                    this.pingInterval = setInterval(() => {
+                        this.instance.send('ping');
+                    }, (response.config.hbInterval + 7) * 1000);
+                }
+            } 
+        }).catch(err => {
+            this.log.error('Login websocket request failed: %s', err);
+        });
+
+        
     }
 
-    onmessage(data, flags, number) {
+    /**
+     * Helper method to set the common values all implementations or BaseApiRequest are
+     * expected to include before being sent with API requests. 
+     * @param obj the object to populate the fields in
+     * @returns the updated object. 
+     */
+    populateCommonApiRequestFields(obj) {
+
+        obj.version = '6';
+        obj.ts = '' + Math.floor(new Date().getTime() / 1000);
+        obj.nonce = this.nonce();
+        // obj.appid = 'oeVkj2lYFGnJu5XUtWisfW4utiN4u9Mq';
+        // obj.imei = this.config.imei;
+        obj.os = 'iOS';
+        obj.model = 'iPhone10,6';
+        obj.romVersion = '11.1.2';
+        // obj.appVersion = '3.5.3';
+
+        return obj;
+    }
+
+    onmessage(data, number) {
         // console.log("WebSocketClient: message", arguments);
     }
 
@@ -88,6 +207,27 @@ module.exports = class WebSocketClient {
 
     onclose(e) {
         // console.log("WebSocketClient: closed", arguments);
+    }
+
+
+    /**
+     * Get the next sequence number for a websocket request.
+     * 
+     * @returns the sequence number
+     */
+    getSequence() {
+        let time_stamp = new Date() / 1000;
+        let sequence = Math.floor(time_stamp * 1000);
+        return "" + sequence;
+    }
+
+    /**
+     * Generate a nonce for sending with API requests. 
+     * 
+     * @returns the base64 encoded nonce.
+     */
+    nonce() {
+        return crypto.randomBytes(16).toString('base64');
     }
 
 }

--- a/lib/webSocketClient.js
+++ b/lib/webSocketClient.js
@@ -1,12 +1,12 @@
 const crypto = require('crypto');
+
+const Cache = require('./cache');
 const WebSocket = require('ws');
 const WebSocketAsPromised = require('websocket-as-promised');
 
 /**
  * Class exposing methods to interact with Ewelink through their websocket API.
  * 
- * TODO:
- * - Rate limiting
  */
 module.exports = class WebSocketClient {
 
@@ -20,10 +20,8 @@ module.exports = class WebSocketClient {
         this.log = log;
         this.config = config;
 
-        /* Map we will use as a cache to prevent spamming the websocket API.
-         * The cache duration is in milliseconds. */
-        this.deviceStatusMap = new Map();
-        this.cacheDuration = 500;
+        /* Cache to prevent spamming the websocket API.*/
+        this.deviceStatusMap = new Cache(log);
 
         this.number = 0; // Message number
         this.autoReconnectInterval = 5 * 1000; // ms
@@ -267,18 +265,11 @@ module.exports = class WebSocketClient {
                 this.sleep(delay).then(() => {
                     this.log.debug('After pause for %s', deviceId);
 
-                    //TODO: Need to add something to stop multiple requests for the same device
-
                     this.instance.sendRequest(payload, {
                             requestId: this.getSequence()
                         }).then(result => {
                             /* Add to the cache */
                             this.deviceStatusMap.set(deviceId, result);
-
-                            /* Set a timer to remove the item from the cache */
-                            setInterval(() => {
-                                this.deviceStatusMap.delete(deviceId);
-                            }, this.cacheDuration);
 
                             /* Return */
                             resolve(result);

--- a/lib/webSocketClient.js
+++ b/lib/webSocketClient.js
@@ -2,6 +2,12 @@ const crypto = require('crypto');
 const WebSocket = require('ws');
 const WebSocketAsPromised = require('websocket-as-promised');
 
+/**
+ * Class exposing methods to interact with Ewelink through their websocket API.
+ * 
+ * TODO:
+ * - Rate limiting
+ */
 module.exports = class WebSocketClient {
 
     /**
@@ -13,6 +19,11 @@ module.exports = class WebSocketClient {
 
         this.log = log;
         this.config = config;
+
+        /* Map we will use as a cache to prevent spamming the websocket API.
+         * The cache duration is in milliseconds. */
+        this.deviceStatusMap = new Map();
+        this.cacheDuration = 500;
 
         this.number = 0; // Message number
         this.autoReconnectInterval = 5 * 1000; // ms
@@ -58,29 +69,24 @@ module.exports = class WebSocketClient {
         });
         this.instance.open();
 
-        // this.instance = new WebSocket(this.url);
-        // this.instance.on('open', () => {
         this.instance.onOpen.addListener(() => {
             this.onopen();
         });
     
-        // this.instance.on('message', (data, flags) => {
         this.instance.onSend.addListener(data => {
             this.number++;
             this.onmessage(data, this.number);
         });
     
-        // this.instance.on('close', (e) => {
         this.instance.onClose.addListener(e => {
-            switch (e) {
-                case 1000: // CLOSE_NORMAL
-                    // console.log("WebSocket: closed");
-                    break;
-                default: // Abnormal closure
-                    this.reconnect(e);
-                    break;
+            if (e === 1000) {
+                // CLOSE_NORMAL
+                // console.log("WebSocket: closed");
+            } else {
+                // Abnormal closure
+                this.reconnect(e);
             }
-            platform.log("WebSocket was closed. Reason [%s]", e);
+            this.log("WebSocket was closed. Reason [%s]", e);
             
             /* Close the 'ping' timer */
             this.socketOpen = false;
@@ -93,13 +99,10 @@ module.exports = class WebSocketClient {
         });
         // this.instance.on('error', (e) => {
         this.instance.onError.addListener(e => {
-            switch (e.code) {
-                case 'ECONNREFUSED':
-                    this.reconnect(e);
-                    break;
-                default:
-                    this.onerror(e);
-                    break;
+            if (e.code === 'ECONNREFUSED') {
+                this.reconnect(e);
+            } else {
+                this.onerror(e);
             }
         });
     }
@@ -131,7 +134,7 @@ module.exports = class WebSocketClient {
     onopen(e) {
         // console.log("WebSocketClient: open", arguments);
 
-        this.isSocketOpen = true;
+        this.socketOpen = true;
 
         // We need to authenticate upon opening the connection
 
@@ -169,6 +172,7 @@ module.exports = class WebSocketClient {
                     }, (response.config.hbInterval + 7) * 1000);
                 }
             } 
+
         }).catch(err => {
             this.log.error('Login websocket request failed: %s', err);
         });
@@ -216,9 +220,10 @@ module.exports = class WebSocketClient {
      * @returns the sequence number
      */
     getSequence() {
-        let time_stamp = new Date() / 1000;
-        let sequence = Math.floor(time_stamp * 1000);
-        return "" + sequence;
+        // let time_stamp = new Date() / 1000;
+        // let sequence = Math.floor(time_stamp * 1000);
+        // return "" + sequence;
+        return "" + Date.now();
     }
 
     /**
@@ -229,5 +234,84 @@ module.exports = class WebSocketClient {
     nonce() {
         return crypto.randomBytes(16).toString('base64');
     }
+
+    async getDeviceStatus(deviceId) {
+
+        let cachedDeviceStatus = this.deviceStatusMap.get(deviceId);
+
+        if (cachedDeviceStatus) {
+            this.log.debug('Returning cached status for device %s: %o', 
+                deviceId, cachedDeviceStatus);
+            
+            return cachedDeviceStatus;
+        } else {
+            this.log.debug('Making request for status for device %s', 
+                deviceId);
+
+            let payload = {
+                action: 'query',
+                apikey: this.config.apiKey,
+                deviceid: deviceId,
+                userAgent: 'app',
+                params: []
+            };
+
+            /* Extra undocumented params */
+            payload.at = this.config.authenticationToken;
+            payload = this.populateCommonApiRequestFields(payload);
+
+            return this.instance.sendRequest(payload, {
+                requestId: this.getSequence()
+            });//.then(result => {
+            //     /* Add to the cache */
+            //     this.deviceStatusMap.set(deviceId, result);
+
+            //     /* Set a timer to remove the item from the cache */
+            //     setInterval(() => {
+            //         this.deviceStatusMap.delete(deviceId);
+            //     }, this.cacheDuration);
+            // });
+        }
+    }
+
+    async updateDeviceStatus(deviceId, params) {
+
+        /* Documentation says action value should be 'action:update', this is
+         * incorrect, should just be 'update'
+         */
+        let payload = {
+            action: 'update',
+            apikey: this.config.apiKey,
+            deviceid: deviceId,
+            userAgent: 'app',
+            params: params
+        };
+
+        /* Extra undocumented params */
+        payload.at = this.config.authenticationToken;
+        payload = this.populateCommonApiRequestFields(payload);
+
+        return this.instance.sendRequest(payload, {
+            requestId: this.getSequence()
+        });
+
+    }
+
+    /**
+     * Helper method that can be used to "wait" for a period of time. 
+     * 
+     * Callers can do something like this to introduce a 1s delay in their execution. 
+     * "await sleep(1000);"
+     * 
+     * See: https://stackoverflow.com/a/41957152/230449
+     * 
+     * @param {number} ms the number of millseconds to sleep for. 
+     * @returns a promise that will be resolved after the supplied duration has passed. 
+     */
+    sleep(ms) {
+        return new Promise((resolve) => {
+          setTimeout(resolve, ms);
+        });
+    } 
 
 }

--- a/lib/webSocketClient.js
+++ b/lib/webSocketClient.js
@@ -52,12 +52,9 @@ module.exports = class WebSocketClient {
             extractRequestId: data => data && data.sequence,
 
             /* Need to specify how JSON is serialized */
-            packMessage: data => {
-                this.log.debug('packMessage message: %o', data);
-                return JSON.stringify(data);
-            },
+            packMessage: data => JSON.stringify(data),
             unpackMessage: data => {
-                this.log.debug('unpackMessage message: %o', data);
+                this.log.debug('unpackMessage: %s', data);
                 if (data === 'pong') {
                     /* Heartbeat response, just return as-is */
                     return data;
@@ -73,7 +70,7 @@ module.exports = class WebSocketClient {
             this.onopen();
         });
     
-        this.instance.onSend.addListener(data => {
+        this.instance.onUnpackedMessage.addListener(data => {
             this.number++;
             this.onmessage(data, this.number);
         });
@@ -260,6 +257,12 @@ module.exports = class WebSocketClient {
             payload.at = this.config.authenticationToken;
             payload = this.populateCommonApiRequestFields(payload);
 
+            /* Introduce a small pause to prevent spamming the websocket */
+            // await this.sleep(200);
+
+            //TODO: Need to add something to stop multiple requests for the same device
+
+            //TODO: Add storing details in the cache here
             return this.instance.sendRequest(payload, {
                 requestId: this.getSequence()
             });//.then(result => {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/howanghk/homebridge-ewelink"
   },
   "dependencies": {
+    "multicast-dns": "^7.2.2",
     "nonce": "^1.0.4",
     "request-json": "^0.6.2",
     "ws": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "multicast-dns": "^7.2.2",
     "nonce": "^1.0.4",
     "request-json": "^0.6.2",
+    "websocket-as-promised": "^1.0.1",
     "ws": "^3.3.2"
   }
 }


### PR DESCRIPTION
This is a much bigger set of changes than I was intending to include in a single PR, but here it goes. I think it is time to start getting these changes looked at by a wider group. Ideally we can get these tested & merged in. 

This has done a pile of refactoring to remove duplication in the plugin for how it was reading the status for devices. As part of this, and adding experimental support for getting the device status with WebSockets (#74), the approach to loading data has been separated out. In lib, there is now an `api.js` file which handles all the API operations which the plugin was performing. This then internally deals with working out what needs to go to the REST, WebSockets and Lan mode APIs depending on the feature flags enabled. 

These feature flags are now documented in the README file, which is worth reading to get a feel for the changes being introduced.

There is also an additional `fakeFan` setting which I have been using to allow testing of Fan type devices. This refactoring has removed a lot of duplication in how the fan Active and Light statuses were being loaded, as these were just switches. 

This has introduced for the LAN and WebSocket clients caching of device status information (albeit for a short period for the latter), which should help with issues where the websocket is closed due to too many quick requests being made for the same device. 

The main area I have been unable to test changes in is for Blinds, so hoping someone is able to try some pre-release code to check if my branch functions. 

